### PR TITLE
feat: add Matrix transport (Element X, Element Web, FluffyChat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Matrix transport via `matrix-bot-sdk` — works with Element X, Element Web, FluffyChat, any Matrix client. Auto-joins rooms, group chat support with mention detection, optional E2EE (Rust SDK crypto store)
 - `hideToolCalls` config option and `/msg-bridge toggletools` command to hide tool call summaries in remote messages
-- Empty-message guard in all transports (Discord, Telegram, Slack, WhatsApp) to prevent provider errors on whitespace-only payloads
+- Empty-message guard in all transports (Discord, Telegram, Slack, WhatsApp, Matrix) to prevent provider errors on whitespace-only payloads
 
 ### Fixed
 - `sendUserMessage` crash when a remote message arrives mid-turn — messages are now queued via `{ deliverAs: "followUp" }` so each remote message gets its own turn after the current one finishes, instead of being interleaved into it (fixes #10)

--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ export PI_MATRIX_HOMESERVER="https://matrix.org"
 export PI_MATRIX_ACCESS_TOKEN="syt_..."
 ```
 
-E2EE is enabled by default. Verify the bot's device once from another Matrix client (Element, etc.) — until verified, encrypted rooms cannot decrypt messages in either direction. Set `"encryption": false` in `matrix` config to disable.
+E2EE is **on by default**. Verify the bot's device once from another Matrix client (Element, etc.) — until verified, encrypted rooms can't be decrypted in either direction.
+
+Set `"encryption": false` in the `matrix` config to disable — useful for non-encrypted rooms only, or to bypass crypto-store/server desync (e.g. `M_UNKNOWN: One time key … already exists`). **Caveat:** with E2EE off, the homeserver sees plaintext, and the bot can't participate in encrypted rooms at all.
 
 ### 3. Connect
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pi-messenger-bridge
 
-Bridge common messengers (Telegram, WhatsApp, Slack, Discord) into pi.
+Bridge common messengers (Telegram, WhatsApp, Slack, Discord, Matrix) into pi.
 
 Remote users can interact with your pi coding agent via their messenger app.
 
@@ -10,7 +10,7 @@ https://github.com/user-attachments/assets/cd64360e-e8cd-4820-a67f-bd127c5d6035
 
 ## Features
 
-- 📱 Multi-messenger support (Telegram, WhatsApp, Slack, Discord)
+- 📱 Multi-messenger support (Telegram, WhatsApp, Slack, Discord, Matrix)
 - 🔐 Challenge-based authentication (6-digit codes)
 - 🎛️ Interactive menu (`/msg-bridge`) for setup and management
 - 🔒 Single-instance guard — prevents duplicate bot polling with sub-agents
@@ -90,6 +90,26 @@ Or set via environment variable:
 export PI_DISCORD_TOKEN="your-bot-token"
 ```
 
+#### Matrix
+
+Works with any Matrix homeserver — Element X, Element Web, FluffyChat, etc. The bot auto-joins rooms it's invited to.
+
+1. Register a bot account on your homeserver (or reuse an existing user)
+2. Get an access token: log in once via Element and copy from **Settings → Help & About → Advanced**, or POST to `/_matrix/client/v3/login`
+3. Note your homeserver URL (e.g. `https://matrix.org`)
+
+```bash
+/msg-bridge configure matrix <homeserver-url> <access-token>
+```
+
+Or set via environment variables:
+```bash
+export PI_MATRIX_HOMESERVER="https://matrix.org"
+export PI_MATRIX_ACCESS_TOKEN="syt_..."
+```
+
+E2EE is enabled by default. Verify the bot's device once from another Matrix client (Element, etc.) — until verified, encrypted rooms cannot decrypt messages in either direction. Set `"encryption": false` in `matrix` config to disable.
+
 ### 3. Connect
 
 ```bash
@@ -127,6 +147,7 @@ Example config:
   "whatsapp": { "authPath": "..." },
   "slack": { "botToken": "...", "appToken": "..." },
   "discord": { "token": "..." },
+  "matrix": { "homeserverUrl": "https://matrix.org", "accessToken": "syt_...", "encryption": true },
   "auth": {
     "trustedUsers": ["telegram:123", "whatsapp:456"],
     "adminUserId": "telegram:789"
@@ -146,6 +167,8 @@ Environment variables override file config:
 - `PI_SLACK_BOT_TOKEN` — Slack bot token (xoxb-...)
 - `PI_SLACK_APP_TOKEN` — Slack app token (xapp-...)
 - `PI_DISCORD_TOKEN` — Discord bot token
+- `PI_MATRIX_HOMESERVER` — Matrix homeserver URL (e.g. `https://matrix.org`)
+- `PI_MATRIX_ACCESS_TOKEN` — Matrix access token
 - `MSG_BRIDGE_DEBUG` — Enable debug logging (true/false)
 
 ## Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@slack/bolt": "^4.6.0",
         "@whiskeysockets/baileys": "^7.0.0-rc.9",
         "discord.js": "^14.25.1",
+        "matrix-bot-sdk": "^0.8.0",
         "node-telegram-bot-api": "^0.67.0",
         "qrcode-terminal": "^0.12.0"
       },
@@ -23,6 +24,7 @@
         "@types/node": "^25.3.0",
         "@types/node-telegram-bot-api": "^0.64.14",
         "@types/qrcode-terminal": "^0.12.2",
+        "fast-check": "^4.5.3",
         "typescript": "^6.0.2",
         "vitest": "^4.1.1"
       },
@@ -1970,6 +1972,20 @@
         "koffi": "^2.9.0"
       }
     },
+    "node_modules/@matrix-org/matrix-sdk-crypto-nodejs": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.4.0.tgz",
+      "integrity": "sha512-+qqgpn39XFSbsD0dFjssGO9vHEP7sTyfs8yTpt8vuqWpUpF20QMwpCZi0jpYw7GxjErNTsMshopuo8677DfGEA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "https-proxy-agent": "^7.0.5",
+        "node-downloader-helper": "^2.1.9"
+      },
+      "engines": {
+        "node": ">= 22"
+      }
+    },
     "node_modules/@mistralai/mistralai": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
@@ -2382,6 +2398,19 @@
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/@silvia-odwyer/photon-node": {
@@ -3345,7 +3374,6 @@
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -3374,7 +3402,6 @@
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3422,8 +3449,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
@@ -3439,6 +3465,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "license": "MIT"
     },
     "node_modules/@types/mime-types": {
@@ -3485,15 +3517,13 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/request": {
       "version": "2.48.13",
@@ -3741,7 +3771,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -3782,6 +3811,12 @@
         }
       }
     },
+    "node_modules/another-json": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/another-json/-/another-json-0.2.0.tgz",
+      "integrity": "sha512-/Ndrl68UQLhnCdsAzEXLMFuOR546o2qbYRqCglaNHbjXrwG1ayTcdwr3zkSGOGtGXDyR5X9nCFfnyG2AFJIsqg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3796,7 +3831,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3830,6 +3864,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
     },
     "node_modules/array.prototype.findindex": {
       "version": "2.2.4",
@@ -3918,6 +3958,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "license": "MIT"
     },
     "node_modules/async-mutex": {
       "version": "0.5.0",
@@ -4047,6 +4093,24 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
@@ -4304,7 +4368,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4317,7 +4380,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -4496,6 +4558,15 @@
         }
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -4563,6 +4634,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4625,6 +4706,61 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dunder-proto": {
@@ -4696,6 +4832,18 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -4862,6 +5010,18 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/escodegen": {
       "version": "2.1.0",
@@ -5033,6 +5193,29 @@
       ],
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5043,8 +5226,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -5586,6 +5768,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -5647,7 +5835,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/gtoken": {
@@ -5669,7 +5856,6 @@
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -5680,7 +5866,6 @@
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "deprecated": "this library is no longer supported",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -5694,7 +5879,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5710,8 +5894,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -5729,7 +5912,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5789,6 +5971,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hashery": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.4.0.tgz",
@@ -5840,6 +6032,47 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/htmlencode": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/htmlencode/-/htmlencode-0.0.4.tgz",
+      "integrity": "sha512-0uDvNVpzj/E2TfvLLyyXhKBRvF1y84aZsyRxRXFsQobnHaL4pcaXk+Y9cnFlvnxrBLeXDNq/VJBD+ngdBgQG1w==",
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/http-errors": {
@@ -5894,7 +6127,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -6189,6 +6421,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-promise": {
@@ -6512,6 +6753,15 @@
       "optional": true,
       "funding": {
         "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/libsignal": {
@@ -6883,6 +7133,28 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/lowdb": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-1.0.0.tgz",
+      "integrity": "sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.3",
+        "is-promise": "^2.1.0",
+        "lodash": "4",
+        "pify": "^3.0.0",
+        "steno": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/lowdb/node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
@@ -6930,6 +7202,393 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/matrix-bot-sdk": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/matrix-bot-sdk/-/matrix-bot-sdk-0.8.0.tgz",
+      "integrity": "sha512-sCY5UvZfsZhJdCjSc8wZhGhIHOe5cSFSILxx9Zp5a/NEXtmQ6W/bIhefIk4zFAZXetFwXsgvKh1960k1hG5WDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@matrix-org/matrix-sdk-crypto-nodejs": "^0.4.0",
+        "@types/express": "^4.17.20",
+        "another-json": "^0.2.0",
+        "async-lock": "^1.4.0",
+        "chalk": "4",
+        "express": "^4.18.2",
+        "glob-to-regexp": "^0.4.1",
+        "hash.js": "^1.1.7",
+        "html-to-text": "^9.0.5",
+        "htmlencode": "^0.0.4",
+        "lowdb": "1",
+        "lru-cache": "^10.0.1",
+        "mkdirp": "^3.0.1",
+        "morgan": "^1.10.0",
+        "postgres": "^3.4.1",
+        "request": "^2.88.2",
+        "request-promise": "^4.2.6",
+        "sanitize-html": "^2.11.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/matrix-bot-sdk/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/matrix-bot-sdk/node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/matrix-bot-sdk/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/matrix-bot-sdk/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/matrix-bot-sdk/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -6949,6 +7608,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mime": {
@@ -6987,6 +7655,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "10.2.4",
@@ -7035,6 +7709,64 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/morgan": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/morgan/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/ms": {
@@ -7090,7 +7822,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7143,6 +7874,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-downloader-helper": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/node-downloader-helper/-/node-downloader-helper-2.1.11.tgz",
+      "integrity": "sha512-882fH2C9AWdiPCwz/2beq5t8FGMZK9Dx8TJUOIxzMCbvG7XUKM5BuJwN5f0NKo4SCQK6jR4p2TPm54mYGdGchQ==",
+      "license": "MIT",
+      "bin": {
+        "ndh": "bin/ndh"
+      },
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/node-fetch": {
@@ -7207,7 +7950,6 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -7291,6 +8033,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -7449,6 +8200,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
@@ -7472,6 +8229,19 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -7549,6 +8319,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -7566,7 +8345,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -7580,6 +8358,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/pino": {
@@ -7632,7 +8419,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7655,6 +8441,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.9.tgz",
+      "integrity": "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
       }
     },
     "node_modules/process-nextick-args": {
@@ -7794,6 +8593,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qified": {
       "version": "0.6.0",
@@ -7944,7 +8760,6 @@
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -7971,6 +8786,25 @@
         "node": ">= 6"
       }
     },
+    "node_modules/request-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
+      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
+      "deprecated": "request-promise has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
     "node_modules/request-promise-core": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
@@ -7986,12 +8820,39 @@
         "request": "^2.34"
       }
     },
+    "node_modules/request-promise/node_modules/request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "license": "ISC",
+      "dependencies": {
+        "lodash": "^4.17.19"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
+    "node_modules/request-promise/node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/request/node_modules/form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -8006,7 +8867,6 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -8022,7 +8882,6 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
       "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -8038,7 +8897,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8048,7 +8906,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -8061,7 +8918,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
       "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -8071,7 +8927,6 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -8086,7 +8941,6 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -8353,6 +9207,63 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
+      "integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^10.1.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -8682,7 +9593,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8752,6 +9662,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/steno": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/steno/-/steno-0.4.4.tgz",
+      "integrity": "sha512-EEHMVYHNXFHfGtgjNITnka0aHhiAlo93F7z2/Pwd+g0teG9CnM3JIINM7hVVB5/rhw9voufD7Wukwgtw2uqh6w==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.3"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -8929,7 +9848,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -9288,7 +10206,6 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -9308,6 +10225,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-messenger-bridge",
   "version": "0.3.0",
-  "description": "Bridge common messengers (Telegram, WhatsApp, Slack, Discord) into pi",
+  "description": "Bridge common messengers (Telegram, WhatsApp, Slack, Discord, Matrix) into pi",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "pi": {
@@ -29,6 +29,8 @@
     "whatsapp",
     "slack",
     "discord",
+    "matrix",
+    "element",
     "messenger",
     "bridge",
     "bot",
@@ -65,6 +67,7 @@
     "@slack/bolt": "^4.6.0",
     "@whiskeysockets/baileys": "^7.0.0-rc.9",
     "discord.js": "^14.25.1",
+    "matrix-bot-sdk": "^0.8.0",
     "node-telegram-bot-api": "^0.67.0",
     "qrcode-terminal": "^0.12.0"
   },
@@ -76,6 +79,7 @@
     "@types/node": "^25.3.0",
     "@types/node-telegram-bot-api": "^0.64.14",
     "@types/qrcode-terminal": "^0.12.2",
+    "fast-check": "^4.5.3",
     "typescript": "^6.0.2",
     "vitest": "^4.1.1"
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,12 @@ export function loadConfig(): MsgBridgeConfig {
   if (process.env.PI_DISCORD_TOKEN) {
     config.discord = { token: process.env.PI_DISCORD_TOKEN };
   }
+  if (process.env.PI_MATRIX_HOMESERVER && process.env.PI_MATRIX_ACCESS_TOKEN) {
+    config.matrix = {
+      homeserverUrl: process.env.PI_MATRIX_HOMESERVER,
+      accessToken: process.env.PI_MATRIX_ACCESS_TOKEN,
+    };
+  }
 
   return config;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { extractTextFromMessage, formatToolCalls, hasToolCalls, splitMessage } f
 import { acquireLock, releaseLock } from "./lock.js";
 import { DiscordProvider } from "./transports/discord.js";
 import { TransportManager } from "./transports/manager.js";
+import { MatrixProvider } from "./transports/matrix.js";
 import { SlackProvider } from "./transports/slack.js";
 import { TelegramProvider } from "./transports/telegram.js";
 import { WhatsAppProvider } from "./transports/whatsapp.js";
@@ -139,6 +140,15 @@ export default function (pi: ExtensionAPI): void {
           Promise.resolve().then(() => {
             const discordProvider = new DiscordProvider(config.discord!, auth);
             transportManager.addTransport(discordProvider);
+          })
+        );
+      }
+
+      if (config.matrix?.homeserverUrl && config.matrix?.accessToken) {
+        transportPromises.push(
+          Promise.resolve().then(() => {
+            const matrixProvider = new MatrixProvider(config.matrix!, auth);
+            transportManager.addTransport(matrixProvider);
           })
         );
       }
@@ -291,6 +301,8 @@ export default function (pi: ExtensionAPI): void {
           "                              Configure Telegram bot",
           "/msg-bridge configure whatsapp",
           "                              Configure WhatsApp (scan QR)",
+          "/msg-bridge configure matrix <homeserver-url> <access-token>",
+          "                              Configure Matrix (Element X, etc)",
           "/msg-bridge widget            Toggle status widget on/off",
           "/msg-bridge toggletools       Toggle tool call visibility",
           "",
@@ -437,6 +449,34 @@ export default function (pi: ExtensionAPI): void {
               }
             } else {
               context.ui.notify("✅ Discord configured (another instance is connected — run /msg-bridge connect later)", "info");
+            }
+            updateWidget();
+            break;
+          }
+
+          case "matrix": {
+            const matrixParts = token.split(/\s+/);
+            const homeserverUrl = matrixParts[0];
+            const matrixAccessToken = matrixParts.slice(1).join(" ");
+            if (!homeserverUrl || !matrixAccessToken) {
+              context.ui.notify("Usage: /msg-bridge configure matrix <homeserver-url> <access-token>", "error");
+              return;
+            }
+
+            config.matrix = { homeserverUrl, accessToken: matrixAccessToken };
+            saveConfig(config);
+            const matrixProvider = new MatrixProvider(config.matrix, auth);
+            transportManager.addTransport(matrixProvider);
+            if (acquireLock()) {
+              try {
+                await matrixProvider.connect();
+                context.ui.notify("✅ Matrix configured and connected", "info");
+              } catch (err) {
+                releaseLock();
+                context.ui.notify(`⚠️ Matrix setup error: ${(err as Error).message}`, "error");
+              }
+            } else {
+              context.ui.notify("✅ Matrix configured (another instance is connected — run /msg-bridge connect later)", "info");
             }
             updateWidget();
             break;

--- a/src/transports/matrix-utils.test.ts
+++ b/src/transports/matrix-utils.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from "vitest";
 import * as fc from "fast-check";
+import { describe, expect, it } from "vitest";
 import {
   escapeHtml,
+  extractUsername,
   formatForMatrix,
   shouldSkipEvent,
-  extractUsername,
-  wasBotMentioned,
   stripBotMention,
+  wasBotMentioned,
 } from "./matrix-utils.js";
 
 // ─── escapeHtml ───────────────────────────────────────────────
@@ -273,7 +273,7 @@ describe("formatForMatrix properties", () => {
 
   it("formattedBody is undefined when no markdown chars present", () => {
     // Generate strings that don't contain markdown-triggering chars
-    const noMarkdown = fc.string().filter((s) => !/[*_`#\[]/.test(s));
+    const noMarkdown = fc.string().filter((s) => !/[*_`#[]/.test(s));
     fc.assert(
       fc.property(noMarkdown, (text) => {
         const result = formatForMatrix(text);

--- a/src/transports/matrix-utils.test.ts
+++ b/src/transports/matrix-utils.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect } from "vitest";
+import * as fc from "fast-check";
+import {
+  escapeHtml,
+  formatForMatrix,
+  shouldSkipEvent,
+  extractUsername,
+  wasBotMentioned,
+  stripBotMention,
+} from "./matrix-utils.js";
+
+// ─── escapeHtml ───────────────────────────────────────────────
+
+describe("escapeHtml", () => {
+  it("escapes ampersand", () => {
+    expect(escapeHtml("a & b")).toBe("a &amp; b");
+  });
+
+  it("escapes angle brackets", () => {
+    expect(escapeHtml("<script>")).toBe("&lt;script&gt;");
+  });
+
+  it("escapes double quotes", () => {
+    expect(escapeHtml('say "hello"')).toBe("say &quot;hello&quot;");
+  });
+
+  it("handles all special chars together", () => {
+    expect(escapeHtml('<a href="x">&')).toBe("&lt;a href=&quot;x&quot;&gt;&amp;");
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(escapeHtml("hello world")).toBe("hello world");
+  });
+
+  it("handles empty string", () => {
+    expect(escapeHtml("")).toBe("");
+  });
+});
+
+// ─── formatForMatrix ──────────────────────────────────────────
+
+describe("formatForMatrix", () => {
+  it("returns plain body only for text without markdown", () => {
+    const result = formatForMatrix("hello world");
+    expect(result).toEqual({ body: "hello world" });
+    expect(result.formattedBody).toBeUndefined();
+  });
+
+  it("converts **bold** to <strong>", () => {
+    const result = formatForMatrix("this is **bold** text");
+    expect(result.body).toBe("this is **bold** text");
+    expect(result.formattedBody).toContain("<strong>bold</strong>");
+  });
+
+  it("converts *italic* to <em>", () => {
+    const result = formatForMatrix("this is *italic* text");
+    expect(result.formattedBody).toContain("<em>italic</em>");
+  });
+
+  it("does not confuse **bold** with *italic*", () => {
+    const result = formatForMatrix("**bold** and *italic*");
+    expect(result.formattedBody).toContain("<strong>bold</strong>");
+    expect(result.formattedBody).toContain("<em>italic</em>");
+  });
+
+  it("converts [text](url) to <a href>", () => {
+    const result = formatForMatrix("click [here](https://example.com)");
+    expect(result.formattedBody).toContain('<a href="https://example.com">here</a>');
+  });
+
+  it("converts newlines to <br>", () => {
+    const result = formatForMatrix("line *one*\nline two");
+    expect(result.formattedBody).toContain("<br>");
+  });
+
+  it("protects inline code from markdown conversion", () => {
+    const result = formatForMatrix("use `**not bold**` here");
+    expect(result.formattedBody).toContain("<code>");
+    expect(result.formattedBody).not.toContain("<strong>not bold</strong>");
+  });
+
+  it("protects code blocks from markdown conversion", () => {
+    const result = formatForMatrix("```\n**not bold**\n```");
+    expect(result.formattedBody).toContain("<pre><code>");
+    expect(result.formattedBody).not.toContain("<strong>");
+  });
+
+  it("adds language class to code blocks", () => {
+    const result = formatForMatrix("```typescript\nconst x = 1;\n```");
+    expect(result.formattedBody).toContain('class="language-typescript"');
+  });
+
+  it("escapes HTML inside code blocks", () => {
+    const result = formatForMatrix("```\n<script>alert('xss')</script>\n```");
+    expect(result.formattedBody).toContain("&lt;script&gt;");
+    expect(result.formattedBody).not.toContain("<script>");
+  });
+
+  it("escapes HTML inside inline code", () => {
+    const result = formatForMatrix("use `<div>` tag");
+    expect(result.formattedBody).toContain("&lt;div&gt;");
+  });
+
+  it("preserves original text as body even when formatted", () => {
+    const original = "**bold** and `code`";
+    const result = formatForMatrix(original);
+    expect(result.body).toBe(original);
+  });
+});
+
+// ─── shouldSkipEvent ──────────────────────────────────────────
+
+describe("shouldSkipEvent", () => {
+  const botUserId = "@bot:matrix.org";
+  const connectedAt = 1000;
+  const joinedRooms = new Set(["!room1:matrix.org", "!room2:matrix.org"]);
+
+  function makeEvent(overrides: Record<string, any> = {}) {
+    return {
+      sender: "@user:matrix.org",
+      origin_server_ts: 2000,
+      content: { msgtype: "m.text", body: "hello" },
+      ...overrides,
+    };
+  }
+
+  it("returns null for a valid message", () => {
+    expect(shouldSkipEvent(makeEvent(), botUserId, connectedAt, joinedRooms, "!room1:matrix.org")).toBeNull();
+  });
+
+  it("skips own messages", () => {
+    expect(shouldSkipEvent(makeEvent({ sender: botUserId }), botUserId, connectedAt, joinedRooms, "!room1:matrix.org"))
+      .toBe("own_message");
+  });
+
+  it("skips stale events (before connectedAt)", () => {
+    expect(shouldSkipEvent(makeEvent({ origin_server_ts: 500 }), botUserId, connectedAt, joinedRooms, "!room1:matrix.org"))
+      .toBe("stale");
+  });
+
+  it("skips events at exactly connectedAt (boundary: < not <=)", () => {
+    // connectedAt=1000, event ts=1000 → NOT stale (< is strict)
+    expect(shouldSkipEvent(makeEvent({ origin_server_ts: 1000 }), botUserId, connectedAt, joinedRooms, "!room1:matrix.org"))
+      .toBeNull();
+  });
+
+  it("skips events with ts=999 (one below connectedAt)", () => {
+    expect(shouldSkipEvent(makeEvent({ origin_server_ts: 999 }), botUserId, connectedAt, joinedRooms, "!room1:matrix.org"))
+      .toBe("stale");
+  });
+
+  it("skips non-text messages", () => {
+    expect(shouldSkipEvent(makeEvent({ content: { msgtype: "m.image", body: "photo" } }), botUserId, connectedAt, joinedRooms, "!room1:matrix.org"))
+      .toBe("not_text");
+  });
+
+  it("skips messages with no content", () => {
+    expect(shouldSkipEvent(makeEvent({ content: undefined }), botUserId, connectedAt, joinedRooms, "!room1:matrix.org"))
+      .toBe("not_text");
+  });
+
+  it("skips messages with no body", () => {
+    expect(shouldSkipEvent(makeEvent({ content: { msgtype: "m.text" } }), botUserId, connectedAt, joinedRooms, "!room1:matrix.org"))
+      .toBe("not_text");
+  });
+
+  it("skips edits (m.new_content present)", () => {
+    expect(shouldSkipEvent(
+      makeEvent({ content: { msgtype: "m.text", body: "edited", "m.new_content": { body: "new" } } }),
+      botUserId, connectedAt, joinedRooms, "!room1:matrix.org"
+    )).toBe("edit");
+  });
+
+  it("skips events from rooms not in joinedRooms", () => {
+    expect(shouldSkipEvent(makeEvent(), botUserId, connectedAt, joinedRooms, "!unknown:matrix.org"))
+      .toBe("not_joined");
+  });
+
+  it("handles missing origin_server_ts (defaults to 0, always stale)", () => {
+    expect(shouldSkipEvent(makeEvent({ origin_server_ts: undefined }), botUserId, connectedAt, joinedRooms, "!room1:matrix.org"))
+      .toBe("stale");
+  });
+});
+
+// ─── extractUsername ──────────────────────────────────────────
+
+describe("extractUsername", () => {
+  it("extracts localpart from full MXID", () => {
+    expect(extractUsername("@alice:matrix.org")).toBe("alice");
+  });
+
+  it("handles homeserver with port", () => {
+    expect(extractUsername("@bob:localhost:8448")).toBe("bob");
+  });
+
+  it("handles already plain username", () => {
+    expect(extractUsername("charlie")).toBe("charlie");
+  });
+
+  it("handles MXID without @ prefix", () => {
+    expect(extractUsername("dave:matrix.org")).toBe("dave");
+  });
+});
+
+// ─── wasBotMentioned ─────────────────────────────────────────
+
+describe("wasBotMentioned", () => {
+  const botUserId = "@pibot:matrix.org";
+
+  it("detects full MXID mention", () => {
+    expect(wasBotMentioned("hey @pibot:matrix.org do this", botUserId)).toBe(true);
+  });
+
+  it("detects @localpart mention (case-insensitive)", () => {
+    expect(wasBotMentioned("hey @Pibot do this", botUserId)).toBe(true);
+  });
+
+  it("detects lowercase @localpart", () => {
+    expect(wasBotMentioned("@pibot help", botUserId)).toBe(true);
+  });
+
+  it("returns false when not mentioned", () => {
+    expect(wasBotMentioned("hello world", botUserId)).toBe(false);
+  });
+
+  it("returns false for bare localpart without @ (avoids false positives on names)", () => {
+    // "pibot" appearing in casual chat without @ shouldn't be a mention
+    expect(wasBotMentioned("pibot help", botUserId)).toBe(false);
+  });
+
+  it("returns false for partial match that isn't the localpart", () => {
+    expect(wasBotMentioned("pi is great", botUserId)).toBe(false);
+  });
+});
+
+// ─── stripBotMention ─────────────────────────────────────────
+
+describe("stripBotMention", () => {
+  const botUserId = "@pibot:matrix.org";
+
+  it("strips full MXID mention", () => {
+    expect(stripBotMention("@pibot:matrix.org help me", botUserId)).toBe("help me");
+  });
+
+  it("strips multiple mentions", () => {
+    expect(stripBotMention("@pibot:matrix.org hey @pibot:matrix.org", botUserId)).toBe("hey");
+  });
+
+  it("returns original text when no mention present", () => {
+    expect(stripBotMention("hello world", botUserId)).toBe("hello world");
+  });
+
+  it("handles mention at end of message", () => {
+    expect(stripBotMention("help @pibot:matrix.org", botUserId)).toBe("help");
+  });
+
+  it("handles message that is only the mention", () => {
+    expect(stripBotMention("@pibot:matrix.org", botUserId)).toBe("");
+  });
+});
+
+// ─── Property tests ───────────────────────────────────────────
+
+describe("formatForMatrix properties", () => {
+  it("body always equals original input (preservation)", () => {
+    fc.assert(
+      fc.property(fc.string(), (text) => {
+        const result = formatForMatrix(text);
+        expect(result.body).toBe(text);
+      })
+    );
+  });
+
+  it("formattedBody is undefined when no markdown chars present", () => {
+    // Generate strings that don't contain markdown-triggering chars
+    const noMarkdown = fc.string().filter((s) => !/[*_`#\[]/.test(s));
+    fc.assert(
+      fc.property(noMarkdown, (text) => {
+        const result = formatForMatrix(text);
+        expect(result.formattedBody).toBeUndefined();
+      })
+    );
+  });
+});
+
+describe("stripBotMention properties", () => {
+  it("result never contains the bot MXID (verification)", () => {
+    // Generate valid-ish MXIDs: @localpart:server
+    const localpart = fc.string({ minLength: 1, maxLength: 10 }).filter((s) => !/[@: ]/.test(s) && s.length > 0);
+    const server = fc.string({ minLength: 1, maxLength: 10 }).filter((s) => !/[@: ]/.test(s) && s.length > 0);
+    const mxid = fc.tuple(localpart, server).map(([user, host]) => `@${user}:${host}`);
+
+    fc.assert(
+      fc.property(mxid, fc.string(), (botId, prefix) => {
+        const text = `${prefix} ${botId} some text`;
+        const result = stripBotMention(text, botId);
+        expect(result).not.toContain(botId);
+      })
+    );
+  });
+});
+
+describe("escapeHtml properties", () => {
+  it("output never contains raw <, >, &, or \" (except as entities)", () => {
+    fc.assert(
+      fc.property(fc.string(), (text) => {
+        const result = escapeHtml(text);
+        // After escaping, the only < > & " should be inside entity sequences
+        const withoutEntities = result
+          .replace(/&amp;/g, "")
+          .replace(/&lt;/g, "")
+          .replace(/&gt;/g, "")
+          .replace(/&quot;/g, "");
+        expect(withoutEntities).not.toMatch(/[<>"&]/);
+      })
+    );
+  });
+});
+
+// Excluded from testing (design decisions / integration-only, verified by inspection):
+// - connect()/disconnect() lifecycle (requires real MatrixClient)
+// - sendMessage()/sendTyping() (thin SDK wrappers)
+// - index.ts wiring (env var reading, command handler plumbing)
+// - Widget abbreviation (mx)

--- a/src/transports/matrix-utils.ts
+++ b/src/transports/matrix-utils.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure utility functions for Matrix transport.
+ * Extracted for testability — no SDK or network dependencies.
+ */
+
+/** Escape HTML special characters */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Convert markdown to Matrix HTML. Returns plain body + optional formatted HTML. */
+export function formatForMatrix(text: string): { body: string; formattedBody?: string } {
+  const hasMarkdown = /[*_`#\[]/.test(text);
+  if (!hasMarkdown) {
+    return { body: text };
+  }
+
+  let html = text;
+
+  // Protect code blocks
+  const codeBlocks: string[] = [];
+  html = html.replace(/```(\w*)\n?([\s\S]*?)```/g, (_, lang, code) => {
+    codeBlocks.push(`<pre><code${lang ? ` class="language-${lang}"` : ""}>${escapeHtml(code.trimEnd())}</code></pre>`);
+    return `__CODEBLOCK_${codeBlocks.length - 1}__`;
+  });
+
+  // Protect inline code
+  const inlineCodes: string[] = [];
+  html = html.replace(/`([^`]+)`/g, (_, code) => {
+    inlineCodes.push(`<code>${escapeHtml(code)}</code>`);
+    return `__INLINECODE_${inlineCodes.length - 1}__`;
+  });
+
+  // Bold
+  html = html.replace(/\*\*([^*]+?)\*\*/g, "<strong>$1</strong>");
+  // Italic
+  html = html.replace(/(?<!\*)\*(?!\*)([^*]+?)(?<!\*)\*(?!\*)/g, "<em>$1</em>");
+  // Links
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+  // Newlines to <br>
+  html = html.replace(/\n/g, "<br>");
+
+  // Restore code blocks and inline code
+  html = html.replace(/__CODEBLOCK_(\d+)__/g, (_, idx) => codeBlocks[parseInt(idx)]);
+  html = html.replace(/__INLINECODE_(\d+)__/g, (_, idx) => inlineCodes[parseInt(idx)]);
+
+  return { body: text, formattedBody: html };
+}
+
+/**
+ * Determine whether to skip a Matrix room event before processing.
+ * Returns a reason string if the event should be skipped, or null if it should be processed.
+ */
+export function shouldSkipEvent(
+  event: { sender?: string; origin_server_ts?: number; content?: any },
+  botUserId: string,
+  connectedAt: number,
+  joinedRooms: Set<string>,
+  roomId: string
+): string | null {
+  // Ignore own messages
+  if (event.sender === botUserId) return "own_message";
+
+  // Skip events from before this connection (stale replay from initial sync)
+  const eventTs = event.origin_server_ts || 0;
+  if (eventTs < connectedAt) return "stale";
+
+  // Only process text messages
+  const content = event.content;
+  if (!content || content.msgtype !== "m.text" || !content.body) return "not_text";
+
+  // Ignore edits (we only process original messages)
+  if (content["m.new_content"]) return "edit";
+
+  // Skip events from rooms we're not in (cached, no API call)
+  if (!joinedRooms.has(roomId)) return "not_joined";
+
+  return null;
+}
+
+/** Extract Matrix username (localpart) from a full MXID like @user:matrix.org */
+export function extractUsername(userId: string): string {
+  return userId.replace(/^@/, "").replace(/:.*$/, "");
+}
+
+/**
+ * Check if bot was mentioned, matching either:
+ *  - the full MXID `@user:server`
+ *  - `@localpart` as a leading-@ word (avoids false-positives on bare names)
+ */
+export function wasBotMentioned(messageText: string, botUserId: string): boolean {
+  if (messageText.includes(botUserId)) return true;
+  const localpart = extractUsername(botUserId);
+  if (!localpart) return false;
+  const re = new RegExp(`@${escapeRegExp(localpart)}\\b`, "i");
+  return re.test(messageText);
+}
+
+/** Strip bot mention from message text — symmetric with wasBotMentioned */
+export function stripBotMention(text: string, botUserId: string): string {
+  const localpart = extractUsername(botUserId);
+  let out = text.replace(new RegExp(escapeRegExp(botUserId), "g"), "");
+  if (localpart) {
+    out = out.replace(new RegExp(`@${escapeRegExp(localpart)}\\b`, "gi"), "");
+  }
+  return out.trim();
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/transports/matrix-utils.ts
+++ b/src/transports/matrix-utils.ts
@@ -14,7 +14,7 @@ export function escapeHtml(text: string): string {
 
 /** Convert markdown to Matrix HTML. Returns plain body + optional formatted HTML. */
 export function formatForMatrix(text: string): { body: string; formattedBody?: string } {
-  const hasMarkdown = /[*_`#\[]/.test(text);
+  const hasMarkdown = /[*_`#[]/.test(text);
   if (!hasMarkdown) {
     return { body: text };
   }
@@ -45,8 +45,8 @@ export function formatForMatrix(text: string): { body: string; formattedBody?: s
   html = html.replace(/\n/g, "<br>");
 
   // Restore code blocks and inline code
-  html = html.replace(/__CODEBLOCK_(\d+)__/g, (_, idx) => codeBlocks[parseInt(idx)]);
-  html = html.replace(/__INLINECODE_(\d+)__/g, (_, idx) => inlineCodes[parseInt(idx)]);
+  html = html.replace(/__CODEBLOCK_(\d+)__/g, (_, idx) => codeBlocks[parseInt(idx, 10)]);
+  html = html.replace(/__INLINECODE_(\d+)__/g, (_, idx) => inlineCodes[parseInt(idx, 10)]);
 
   return { body: text, formattedBody: html };
 }

--- a/src/transports/matrix.ts
+++ b/src/transports/matrix.ts
@@ -1,0 +1,305 @@
+import {
+  MatrixClient,
+  SimpleFsStorageProvider,
+  AutojoinRoomsMixin,
+  RustSdkCryptoStorageProvider,
+  RustSdkCryptoStoreType,
+  LogService,
+  RichConsoleLogger,
+} from "matrix-bot-sdk";
+import type { ILogger } from "matrix-bot-sdk";
+import type { ITransportProvider } from "./interface.js";
+import type { ExternalMessage } from "../types.js";
+import type { ChallengeAuth } from "../auth/challenge-auth.js";
+import {
+  formatForMatrix,
+  shouldSkipEvent,
+  extractUsername,
+  wasBotMentioned,
+  stripBotMention,
+} from "./matrix-utils.js";
+import * as path from "path";
+import * as os from "os";
+
+/**
+ * Matrix transport provider using matrix-bot-sdk
+ * Works with any Matrix homeserver — Element X, Element Web, FluffyChat, etc.
+ */
+export class MatrixProvider implements ITransportProvider {
+  readonly type = "matrix";
+  private client?: MatrixClient;
+  private _isConnected = false;
+  private messageHandler?: (message: ExternalMessage) => void;
+  private errorHandler?: (error: Error) => void;
+  private botUserId?: string;
+  private joinedRooms = new Set<string>();
+  private roomMemberCount = new Map<string, number>();
+  private connectedAt = 0;
+
+  constructor(
+    private config: { homeserverUrl: string; accessToken: string; encryption?: boolean },
+    private auth: ChallengeAuth
+  ) {}
+
+  get isConnected(): boolean {
+    return this._isConnected;
+  }
+
+  // Formatting delegated to matrix-utils.ts (pure, testable)
+
+  async connect(): Promise<void> {
+    if (this._isConnected) return;
+
+    const { homeserverUrl, accessToken } = this.config;
+
+    if (!homeserverUrl || !accessToken) {
+      throw new Error("Matrix homeserver URL and access token required");
+    }
+
+    const storagePath = path.join(
+      os.homedir(),
+      ".pi",
+      "msg-bridge-matrix-store.json"
+    );
+    const storage = new SimpleFsStorageProvider(storagePath);
+
+    // Set up E2EE crypto storage if encryption is enabled.
+    // Uses @matrix-org/matrix-sdk-crypto-nodejs (native Rust, SQLite on disk).
+    // Crypto state persists across restarts — same device, same keys.
+    // The device must be verified once from another Matrix client (Element, etc).
+    let cryptoProvider: RustSdkCryptoStorageProvider | undefined;
+    if (this.config.encryption !== false) {
+      try {
+        const cryptoStorePath = path.join(
+          os.homedir(),
+          ".pi",
+          "msg-bridge-matrix-crypto"
+        );
+        cryptoProvider = new RustSdkCryptoStorageProvider(cryptoStorePath, RustSdkCryptoStoreType.Sqlite);
+        console.log("[Matrix] E2EE crypto storage enabled (Rust/SQLite)");
+      } catch (err) {
+        console.warn("[Matrix] E2EE crypto not available, continuing without encryption:", (err as Error).message);
+      }
+    }
+
+    this.client = new MatrixClient(
+      homeserverUrl,
+      accessToken,
+      storage,
+      cryptoProvider
+    );
+
+    // Auto-join rooms the bot is invited to
+    AutojoinRoomsMixin.setupOnClient(this.client);
+
+    // Cache bot user ID (never changes)
+    this.botUserId = await this.client.getUserId();
+
+    // Track room membership and member counts
+    this.client.on("room.join", (roomId: string) => {
+      this.joinedRooms.add(roomId);
+      // Refresh member count asynchronously
+      this.client?.getJoinedRoomMembers(roomId)
+        .then(members => this.roomMemberCount.set(roomId, members.length))
+        .catch(() => {});
+    });
+    this.client.on("room.leave", (roomId: string) => {
+      this.joinedRooms.delete(roomId);
+      this.roomMemberCount.delete(roomId);
+    });
+
+    // Handle incoming messages
+    this.client.on("room.message", async (roomId: string, event: any) => {
+      try {
+        await this.handleMessage(roomId, event);
+      } catch (err) {
+        if (this.errorHandler) {
+          this.errorHandler(err as Error);
+        }
+      }
+    });
+
+    try {
+      // During initial sync the SDK replays historical events and tries to
+      // decrypt them. For E2EE rooms this produces two known error patterns:
+      //   1. "Decryption error" — old messages we don't have keys for
+      //   2. "M_NOT_FOUND"     — stale sync token references a purged event
+      // Our connectedAt filter skips these events anyway, so the errors are
+      // noise. A filtering logger suppresses only these specific patterns.
+      const defaultLogger = new RichConsoleLogger();
+      const syncFilterLogger: ILogger = {
+        info:  (mod, ...args) => defaultLogger.info(mod, ...args),
+        warn:  (mod, ...args) => defaultLogger.warn(mod, ...args),
+        debug: (mod, ...args) => defaultLogger.debug(mod, ...args),
+        trace: (mod, ...args) => defaultLogger.trace(mod, ...args),
+        error: (mod, ...args) => {
+          const msg = args.map(a => typeof a === "string" ? a : JSON.stringify(a)).join(" ");
+          if (mod === "MatrixClientLite" && msg.includes("Decryption error")) return;
+          if (mod === "MatrixHttpClient" && msg.includes("M_NOT_FOUND")) return;
+          defaultLogger.error(mod, ...args);
+        },
+      };
+      LogService.setLogger(syncFilterLogger);
+
+      await this.client.start();
+
+      // Restore default logging — real errors after sync should not be filtered
+      LogService.setLogger(defaultLogger);
+    } catch (error) {
+      // Clean up dangling state so connect() can be retried
+      this.client = undefined;
+      this.botUserId = undefined;
+      this.joinedRooms.clear();
+      this.roomMemberCount.clear();
+      console.error("[Matrix] Failed to connect:", error);
+      throw error;
+    }
+
+    // Seed joined rooms and member count caches
+    const rooms = await this.client.getJoinedRooms();
+    this.joinedRooms = new Set(rooms);
+    await Promise.all(rooms.map(async (roomId) => {
+      try {
+        const members = await this.client!.getJoinedRoomMembers(roomId);
+        this.roomMemberCount.set(roomId, members.length);
+      } catch {
+        // Will be fetched on first message if needed
+      }
+    }));
+    this.connectedAt = Date.now();
+    this._isConnected = true;
+    const cryptoStatus = cryptoProvider ? "E2EE enabled" : "E2EE disabled";
+    console.log(`✅ Matrix connected as ${this.botUserId} (${rooms.length} rooms, ${cryptoStatus})`);
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this._isConnected || !this.client) return;
+
+    this.client.stop();
+    this._isConnected = false;
+    this.client = undefined;
+    this.botUserId = undefined;
+    this.joinedRooms.clear();
+    this.roomMemberCount.clear();
+    this.connectedAt = 0;
+    console.log("[Matrix] Disconnected");
+  }
+
+  async sendMessage(chatId: string, text: string): Promise<void> {
+    if (!this.client) {
+      throw new Error("Matrix client not connected");
+    }
+    if (!text?.trim()) return;
+
+    const { body, formattedBody } = formatForMatrix(text);
+
+    await this.client.sendMessage(chatId, {
+      msgtype: "m.text",
+      body,
+      ...(formattedBody && {
+        format: "org.matrix.custom.html",
+        formatted_body: formattedBody,
+      }),
+    });
+  }
+
+  async sendTyping(chatId: string): Promise<void> {
+    if (!this.client) return;
+    try {
+      await this.client.setTyping(chatId, true, 10000);
+    } catch {
+      // Ignore typing indicator errors
+    }
+  }
+
+  onMessage(handler: (message: ExternalMessage) => void): void {
+    this.messageHandler = handler;
+  }
+
+  onError(handler: (error: Error) => void): void {
+    this.errorHandler = handler;
+  }
+
+  private async handleMessage(roomId: string, event: any): Promise<void> {
+    if (!this.client || !this.botUserId) return;
+
+    // Pure filter — delegates to testable utility
+    const skipReason = shouldSkipEvent(event, this.botUserId, this.connectedAt, this.joinedRooms, roomId);
+    if (skipReason) return;
+
+    const chatId = roomId;
+    const userId = event.sender; // e.g. @user:matrix.org
+    const username = extractUsername(userId);
+    const messageText = event.content.body;
+    const messageId = event.event_id;
+
+    // Determine if group chat from cached member count (no API call per message)
+    let memberCount = this.roomMemberCount.get(roomId);
+    if (memberCount === undefined) {
+      // Cache miss — fetch once and cache
+      try {
+        const members = await this.client.getJoinedRoomMembers(roomId);
+        memberCount = members.length;
+        this.roomMemberCount.set(roomId, memberCount);
+      } catch {
+        memberCount = 2; // Default to DM if we can't check
+      }
+    }
+    const isGroupChat = memberCount > 2;
+
+    // Check if bot was mentioned (pure utility)
+    const wasMentioned = isGroupChat ? wasBotMentioned(messageText, this.botUserId) : false;
+
+    // Check authorization
+    const sendMessageToUser = async (cId: string, text: string) => {
+      await this.sendMessage(cId, text);
+    };
+
+    const isAuthorized = await this.auth.checkAuthorization(
+      userId,
+      chatId,
+      username,
+      isGroupChat,
+      wasMentioned,
+      sendMessageToUser,
+      this.type
+    );
+
+    // Handle challenge codes and commands in DMs
+    if (!isGroupChat && (messageText.startsWith("/") || messageText.match(/^\d{6}$/))) {
+      const handled = await this.auth.handleAdminCommand(
+        messageText,
+        chatId,
+        userId,
+        async (text) => await this.sendMessage(chatId, text),
+        this.type
+      );
+      if (handled) return;
+    }
+
+    if (!isAuthorized) return;
+
+    // Strip bot mention from message (pure utility)
+    const cleanContent = wasMentioned && this.botUserId
+      ? stripBotMention(messageText, this.botUserId)
+      : messageText;
+
+    // Forward to message handler
+    if (this.messageHandler && cleanContent) {
+      const externalMessage: ExternalMessage = {
+        chatId,
+        transport: this.type,
+        content: cleanContent,
+        username,
+        userId,
+        timestamp: new Date(event.origin_server_ts || Date.now()),
+        messageId,
+        isGroupChat,
+        wasMentioned,
+      };
+
+      this.messageHandler(externalMessage);
+    }
+  }
+
+}

--- a/src/transports/matrix.ts
+++ b/src/transports/matrix.ts
@@ -1,25 +1,25 @@
+import type { ILogger } from "matrix-bot-sdk";
 import {
-  MatrixClient,
-  SimpleFsStorageProvider,
   AutojoinRoomsMixin,
+  LogService,
+  MatrixClient,
+  RichConsoleLogger,
   RustSdkCryptoStorageProvider,
   RustSdkCryptoStoreType,
-  LogService,
-  RichConsoleLogger,
+  SimpleFsStorageProvider,
 } from "matrix-bot-sdk";
-import type { ILogger } from "matrix-bot-sdk";
-import type { ITransportProvider } from "./interface.js";
-import type { ExternalMessage } from "../types.js";
+import * as os from "os";
+import * as path from "path";
 import type { ChallengeAuth } from "../auth/challenge-auth.js";
+import type { ExternalMessage } from "../types.js";
+import type { ITransportProvider } from "./interface.js";
 import {
+  extractUsername,
   formatForMatrix,
   shouldSkipEvent,
-  extractUsername,
-  wasBotMentioned,
   stripBotMention,
+  wasBotMentioned,
 } from "./matrix-utils.js";
-import * as path from "path";
-import * as os from "os";
 
 /**
  * Matrix transport provider using matrix-bot-sdk

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,11 @@ export interface MsgBridgeConfig {
   discord?: {
     token: string;
   };
+  matrix?: {
+    homeserverUrl: string;
+    accessToken: string;
+    encryption?: boolean;
+  };
   auth?: {
     trustedUsers?: string[];
     adminUserId?: string;

--- a/src/ui/main-menu.ts
+++ b/src/ui/main-menu.ts
@@ -9,6 +9,7 @@ import { loadConfig, saveConfig } from "../config.js";
 import { acquireLock, releaseLock } from "../lock.js";
 import { DiscordProvider } from "../transports/discord.js";
 import type { TransportManager } from "../transports/manager.js";
+import { MatrixProvider } from "../transports/matrix.js";
 import { SlackProvider } from "../transports/slack.js";
 import { TelegramProvider } from "../transports/telegram.js";
 import { WhatsAppProvider } from "../transports/whatsapp.js";
@@ -95,6 +96,7 @@ async function doConfigure(mctx: MenuContext): Promise<void> {
     "WhatsApp",
     "Slack",
     "Discord",
+    "Matrix",
   ]);
   if (!platform) return;
 
@@ -181,6 +183,28 @@ async function doConfigure(mctx: MenuContext): Promise<void> {
         }
       } else {
         mctx.ui.notify("✅ Discord configured (another instance is connected — run /msg-bridge connect later)", "info");
+      }
+      break;
+    }
+    case "Matrix": {
+      const homeserverUrl = await mctx.ui.input("Matrix homeserver URL (e.g. https://matrix.org)");
+      if (!homeserverUrl) return;
+      const accessToken = await mctx.ui.input("Matrix access token");
+      if (!accessToken) return;
+      config.matrix = { homeserverUrl, accessToken };
+      saveConfig(config);
+      const provider = new MatrixProvider(config.matrix, mctx.auth);
+      mctx.transportManager.addTransport(provider);
+      if (acquireLock()) {
+        try {
+          await provider.connect();
+          mctx.ui.notify("✅ Matrix configured and connected", "info");
+        } catch (err) {
+          releaseLock();
+          mctx.ui.notify(`⚠️ Matrix setup error: ${(err as Error).message}`, "error");
+        }
+      } else {
+        mctx.ui.notify("✅ Matrix configured (another instance is connected — run /msg-bridge connect later)", "info");
       }
       break;
     }


### PR DESCRIPTION
Adds Matrix as a transport alongside Telegram, WhatsApp, Slack, and Discord.

New MatrixProvider using matrix-bot-sdk. Auto-joins rooms, OTP auth, rich HTML formatting, typing indicators, group chat support with mention detection.

Configure via command or env vars. Works with Element X, Element Web, FluffyChat, any Matrix client.