### PR TITLE
Feature/slack brain reaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,29 @@ export PI_WHATSAPP_AUTH_PATH="/path/to/whatsapp-auth"
 
 Create a Slack app with Socket Mode enabled. You need both tokens:
 
+- Bot User OAuth Token: `xoxb-...`
+- App-Level Token: `xapp-...`
+
+Slack app setup:
+
+1. **Socket Mode**: enable Socket Mode.
+2. **App-Level Token**: create an app-level token with scope `connections:write`.
+3. **OAuth & Permissions → Bot Token Scopes**: add these scopes:
+   - `chat:write` — send replies
+   - `users:read` — resolve Slack user names
+   - `channels:read`, `groups:read`, `im:read`, `mpim:read` — inspect conversations and detect DMs vs channels
+   - `channels:history`, `groups:history`, `im:history`, `mpim:history` — receive messages from public channels, private channels, DMs, and multi-person DMs
+   - `reactions:write` — optional; only required if `slack.brainReaction` is enabled
+4. **Event Subscriptions → Subscribe to bot events**: add the message events you want the bridge to receive:
+   - `message.im` — direct messages
+   - `message.mpim` — multi-person DMs
+   - `message.channels` — public channels where the bot is a member
+   - `message.groups` — private channels where the bot is a member
+5. Install/reinstall the app to your workspace after changing scopes or events.
+6. Invite the bot to any channel where it should respond.
+
+Configure the bridge:
+
 ```bash
 /msg-bridge configure slack <bot-token> <app-token>
 ```
@@ -73,6 +96,8 @@ Or set via environment variables:
 export PI_SLACK_BOT_TOKEN="xoxb-..."
 export PI_SLACK_APP_TOKEN="xapp-..."
 ```
+
+Optional processing reaction: set `"brainReaction": true` under `slack` in `~/.pi/msg-bridge.json` to add a 🧠 reaction while pi is working, then remove it when pi is idle. This requires `reactions:write`.
 
 #### Discord
 
@@ -161,7 +186,7 @@ Example config:
 {
   "telegram": { "token": "..." },
   "whatsapp": { "authPath": "..." },
-  "slack": { "botToken": "...", "appToken": "..." },
+  "slack": { "botToken": "...", "appToken": "...", "brainReaction": false },
   "discord": { "token": "..." },
   "matrix": { "homeserverUrl": "https://matrix.org", "accessToken": "syt_...", "encryption": true },
   "auth": {
@@ -173,6 +198,10 @@ Example config:
   "debug": false
 }
 ```
+
+Slack-specific options:
+
+- `slack.brainReaction` — defaults to `false`. Set to `true` to opt in to adding/removing a 🧠 reaction on Slack messages while pi is processing them. Requires Slack `reactions:write` scope.
 
 ## Environment Variables
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,7 @@ export function loadConfig(): MsgBridgeConfig {
   }
   if (process.env.PI_SLACK_BOT_TOKEN && process.env.PI_SLACK_APP_TOKEN) {
     config.slack = {
+      ...config.slack,
       botToken: process.env.PI_SLACK_BOT_TOKEN,
       appToken: process.env.PI_SLACK_APP_TOKEN,
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,8 @@ export default function (pi: ExtensionAPI): void {
       if (config.slack?.botToken && config.slack?.appToken) {
         transportPromises.push(
           Promise.resolve().then(() => {
-            const slackProvider = new SlackProvider(config.slack!, auth);
+            const slackConfig = { ...config.slack!, debug: config.debug };
+            const slackProvider = new SlackProvider(slackConfig, auth);
             transportManager.addTransport(slackProvider);
           })
         );
@@ -427,7 +428,8 @@ export default function (pi: ExtensionAPI): void {
 
             config.slack = { ...config.slack, botToken, appToken };
             saveConfig(config);
-            const slackProvider = new SlackProvider(config.slack, auth);
+            const slackConfig = { ...config.slack, debug: config.debug };
+            const slackProvider = new SlackProvider(slackConfig, auth);
             transportManager.addTransport(slackProvider);
             if (acquireLock()) {
               try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,14 +247,29 @@ export default function (pi: ExtensionAPI): void {
       }
 
       if (!hasPendingTools) {
+        await transportManager.setMessageProcessing(
+          pendingRemoteChat.chatId,
+          pendingRemoteChat.transport,
+          pendingRemoteChat.messageId,
+          false
+        );
         pendingRemoteChat = null;
       }
     } catch (err) {
-      const transport = pendingRemoteChat?.transport ?? "unknown";
+      const pending = pendingRemoteChat;
+      const transport = pending?.transport ?? "unknown";
       ctx.ui.notify(
         `Failed to send response to ${transport}: ${(err as Error).message}`,
         "error"
       );
+      if (pending) {
+        await transportManager.setMessageProcessing(
+          pending.chatId,
+          pending.transport,
+          pending.messageId,
+          false
+        );
+      }
       pendingRemoteChat = null;
     }
   });
@@ -410,7 +425,7 @@ export default function (pi: ExtensionAPI): void {
               return;
             }
 
-            config.slack = { botToken, appToken };
+            config.slack = { ...config.slack, botToken, appToken };
             saveConfig(config);
             const slackProvider = new SlackProvider(config.slack, auth);
             transportManager.addTransport(slackProvider);

--- a/src/transports/interface.ts
+++ b/src/transports/interface.ts
@@ -36,6 +36,13 @@ export interface ITransportProvider {
   sendTyping(chatId: string): Promise<void>;
 
   /**
+   * Optional per-message processing indicator.
+   * Transports that support message reactions can use this to mark an
+   * inbound message as being processed, then clear it when pi is idle.
+   */
+  setMessageProcessing?(chatId: string, messageId: string, processing: boolean): Promise<void>;
+
+  /**
    * Register callback for incoming messages
    * @param handler - Message handler function
    */

--- a/src/transports/manager.ts
+++ b/src/transports/manager.ts
@@ -95,6 +95,21 @@ export class TransportManager {
   }
 
   /**
+   * Set or clear a per-message processing indicator, if the transport supports it.
+   */
+  async setMessageProcessing(
+    chatId: string,
+    transportType: string,
+    messageId: string,
+    processing: boolean
+  ): Promise<void> {
+    const transport = this.transports.get(transportType);
+    if (transport?.isConnected && transport.setMessageProcessing) {
+      await transport.setMessageProcessing(chatId, messageId, processing);
+    }
+  }
+
+  /**
    * Register handler for incoming messages from all transports
    */
   onMessage(handler: (message: ExternalMessage) => void): void {

--- a/src/transports/slack.ts
+++ b/src/transports/slack.ts
@@ -21,6 +21,7 @@ export class SlackProvider implements ITransportProvider {
   private messageHandler?: (message: ExternalMessage) => void;
   private errorHandler?: (error: Error) => void;
   private lastProcessedMessageId = "";
+  private activeBrainReactions = new Set<string>();
   
   // Cache user info to avoid repeated API calls
   private userCache: Map<string, string> = new Map();
@@ -28,7 +29,7 @@ export class SlackProvider implements ITransportProvider {
   private channelCache: Map<string, { isDM: boolean; name?: string }> = new Map();
 
   constructor(
-    private config: { botToken: string; appToken: string },
+    private config: { botToken: string; appToken: string; brainReaction?: boolean },
     private auth: ChallengeAuth
   ) {}
 
@@ -164,6 +165,10 @@ export class SlackProvider implements ITransportProvider {
         return; // Auth handler already sent challenge/error messages
       }
 
+      if (this.config.brainReaction === true) {
+        await this.setMessageProcessing(channelId, ts, true);
+      }
+
       // Forward to message handler
       if (this.messageHandler) {
         const externalMessage: ExternalMessage = {
@@ -210,6 +215,7 @@ export class SlackProvider implements ITransportProvider {
     this._isConnected = false;
     this.userCache.clear();
     this.channelCache.clear();
+    this.activeBrainReactions.clear();
     console.log("[Slack] Disconnected");
   }
 
@@ -230,9 +236,52 @@ export class SlackProvider implements ITransportProvider {
   }
 
   async sendTyping(_chatId: string): Promise<void> {
-    // Slack doesn't support typing indicators for bots
-    // We could potentially add a reaction or use a "thinking" message
-    // but for now we'll just skip it
+    // Slack doesn't support typing indicators for bots.
+  }
+
+  async setMessageProcessing(chatId: string, messageId: string, processing: boolean): Promise<void> {
+    if (this.config.brainReaction !== true) return;
+
+    if (!this.app) {
+      throw new Error("Slack not connected");
+    }
+
+    const key = `${chatId}:${messageId}`;
+
+    try {
+      if (processing) {
+        await this.app.client.reactions.add({
+          channel: chatId,
+          timestamp: messageId,
+          name: "brain",
+        });
+        this.activeBrainReactions.add(key);
+      } else {
+        if (!this.activeBrainReactions.has(key)) return;
+        await this.app.client.reactions.remove({
+          channel: chatId,
+          timestamp: messageId,
+          name: "brain",
+        });
+        this.activeBrainReactions.delete(key);
+      }
+    } catch (error: any) {
+      const slackError = error?.data?.error || error?.message;
+
+      if (processing && slackError === "already_reacted") {
+        this.activeBrainReactions.add(key);
+        return;
+      }
+
+      if (!processing && (slackError === "no_reaction" || slackError === "item_not_found")) {
+        this.activeBrainReactions.delete(key);
+        return;
+      }
+
+      console.warn(
+        `[Slack] Failed to ${processing ? "add" : "remove"} brain reaction: ${slackError || error}`
+      );
+    }
   }
 
   onMessage(handler: (message: ExternalMessage) => void): void {

--- a/src/transports/slack.ts
+++ b/src/transports/slack.ts
@@ -29,7 +29,7 @@ export class SlackProvider implements ITransportProvider {
   private channelCache: Map<string, { isDM: boolean; name?: string }> = new Map();
 
   constructor(
-    private config: { botToken: string; appToken: string; brainReaction?: boolean },
+    private config: { botToken: string; appToken: string; brainReaction?: boolean; debug?: boolean },
     private auth: ChallengeAuth
   ) {}
 
@@ -250,6 +250,9 @@ export class SlackProvider implements ITransportProvider {
 
     try {
       if (processing) {
+        if (this.config.debug) {
+          console.log(`[Slack] Adding brain reaction to message ${messageId} in ${chatId}`);
+        }
         await this.app.client.reactions.add({
           channel: chatId,
           timestamp: messageId,
@@ -258,6 +261,9 @@ export class SlackProvider implements ITransportProvider {
         this.activeBrainReactions.add(key);
       } else {
         if (!this.activeBrainReactions.has(key)) return;
+        if (this.config.debug) {
+          console.log(`[Slack] Removing brain reaction from message ${messageId} in ${chatId}`);
+        }
         await this.app.client.reactions.remove({
           channel: chatId,
           timestamp: messageId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,8 @@ export interface MsgBridgeConfig {
   slack?: {
     botToken: string;
     appToken: string;
+    /** Add a :brain: reaction to Slack messages while pi is processing them. Defaults to false. */
+    brainReaction?: boolean;
   };
   discord?: {
     token: string;

--- a/src/ui/main-menu.ts
+++ b/src/ui/main-menu.ts
@@ -149,7 +149,7 @@ async function doConfigure(mctx: MenuContext): Promise<void> {
       if (!botToken) return;
       const appToken = await mctx.ui.input("Slack app token (xapp-...)");
       if (!appToken) return;
-      config.slack = { botToken, appToken };
+      config.slack = { ...config.slack, botToken, appToken };
       saveConfig(config);
       const provider = new SlackProvider(config.slack, mctx.auth);
       mctx.transportManager.addTransport(provider);

--- a/src/ui/main-menu.ts
+++ b/src/ui/main-menu.ts
@@ -151,7 +151,8 @@ async function doConfigure(mctx: MenuContext): Promise<void> {
       if (!appToken) return;
       config.slack = { ...config.slack, botToken, appToken };
       saveConfig(config);
-      const provider = new SlackProvider(config.slack, mctx.auth);
+      const slackConfig = { ...config.slack, debug: config.debug };
+      const provider = new SlackProvider(slackConfig, mctx.auth);
       mctx.transportManager.addTransport(provider);
       if (acquireLock()) {
         try {


### PR DESCRIPTION
## Description                                                                                                                                                                                                     
                                                                                                                                                                                                                      
   Adds an optional Slack processing indicator that reacts to inbound Slack messages with 🧠 while pi is working, then removes the reaction when processing completes.                                                
                                                                                                                                                                                                                      
   Changes include:                                                                                                                                                                                                   
                                                                                                                                                                                                                      
   - Adds optional `slack.brainReaction` config support.                                                                                                                                                              
   - Adds `setMessageProcessing` as an optional transport capability.                                                                                                                                                 
   - Implements Slack reaction add/remove behavior using `reactions.add` and `reactions.remove`.                                                                                                                      
   - Tracks active brain reactions to avoid unnecessary removals.                                                                                                                                                     
   - Preserves existing Slack config options when env vars or menu configuration update tokens.                                                                                                                       
   - Passes debug config into Slack transport and logs reaction add/remove attempts when debug is enabled.                                                                                                            
   - Updates README Slack setup docs with required scopes, events, and `brainReaction` usage.                                                                                                                         
                                                                                                                                                                                                                      
   ## Why this change is needed                                                                                                                                                                                       
                                                                                                                                                                                                                      
   Slack bots cannot send native typing indicators. The optional 🧠 reaction gives remote Slack users lightweight feedback that pi received their message and is actively processing it.                              
                                                                                                                                                                                                                      
   This is opt-in because it requires the Slack `reactions:write` scope.                                                                                                                                              
                                                                                                                                                                                                                      
   ## Breaking changes                                                                                                                                                                                                
                                                                                                                                                                                                                      
   None.                                                                                                                                                                                                              
                                                                                                                                                                                                                      
   `slack.brainReaction` defaults to disabled, so existing Slack setups continue working unchanged.                                                                                                                   
                                                                                                                                                                                                                      
   ## Testing performed                                                                                                                                                                                               
                                                                                                                                                                                                                      
   - `npm run build`                                                                                                                                                                                                  
   - `npm run test`                                                                                                                                                                                                   
                                                                                                                                                                                                                      
   Result:                                                                                                                                                                                                            
                                                                                                                                                                                                                      
   - 5 test files passed                                                                                                                                                                                              
   - 129 tests passed