### PR TITLE
Feature/slack image handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,29 @@ export PI_WHATSAPP_AUTH_PATH="/path/to/whatsapp-auth"
 
 Create a Slack app with Socket Mode enabled. You need both tokens:
 
+- Bot User OAuth Token: `xoxb-...`
+- App-Level Token: `xapp-...`
+
+Slack app setup:
+
+1. **Socket Mode**: enable Socket Mode.
+2. **App-Level Token**: create an app-level token with scope `connections:write`.
+3. **OAuth & Permissions → Bot Token Scopes**: add these scopes:
+   - `chat:write` — send replies
+   - `users:read` — resolve Slack user names
+   - `channels:read`, `groups:read`, `im:read`, `mpim:read` — inspect conversations and detect DMs vs channels
+   - `channels:history`, `groups:history`, `im:history`, `mpim:history` — receive messages from public channels, private channels, DMs, and multi-person DMs
+   - `reactions:write` — optional; only required if `slack.brainReaction` is enabled
+4. **Event Subscriptions → Subscribe to bot events**: add the message events you want the bridge to receive:
+   - `message.im` — direct messages
+   - `message.mpim` — multi-person DMs
+   - `message.channels` — public channels where the bot is a member
+   - `message.groups` — private channels where the bot is a member
+5. Install/reinstall the app to your workspace after changing scopes or events.
+6. Invite the bot to any channel where it should respond.
+
+Configure the bridge:
+
 ```bash
 /msg-bridge configure slack <bot-token> <app-token>
 ```
@@ -73,6 +96,8 @@ Or set via environment variables:
 export PI_SLACK_BOT_TOKEN="xoxb-..."
 export PI_SLACK_APP_TOKEN="xapp-..."
 ```
+
+Optional processing reaction: set `"brainReaction": true` under `slack` in `~/.pi/msg-bridge.json` to add a 🧠 reaction while pi is working, then remove it when pi is idle. This requires `reactions:write`.
 
 #### Discord
 
@@ -161,7 +186,7 @@ Example config:
 {
   "telegram": { "token": "..." },
   "whatsapp": { "authPath": "..." },
-  "slack": { "botToken": "...", "appToken": "..." },
+  "slack": { "botToken": "...", "appToken": "...", "brainReaction": false },
   "discord": { "token": "..." },
   "matrix": { "homeserverUrl": "https://matrix.org", "accessToken": "syt_...", "encryption": true },
   "auth": {
@@ -173,6 +198,10 @@ Example config:
   "debug": false
 }
 ```
+
+Slack-specific options:
+
+- `slack.brainReaction` — defaults to `false`. Set to `true` to opt in to adding/removing a 🧠 reaction on Slack messages while pi is processing them. Requires Slack `reactions:write` scope.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Slack app setup:
    - `users:read` — resolve Slack user names
    - `channels:read`, `groups:read`, `im:read`, `mpim:read` — inspect conversations and detect DMs vs channels
    - `channels:history`, `groups:history`, `im:history`, `mpim:history` — receive messages from public channels, private channels, DMs, and multi-person DMs
+   - `files:read` — download image files attached to Slack messages so they can be sent to the model
    - `reactions:write` — optional; only required if `slack.brainReaction` is enabled
 4. **Event Subscriptions → Subscribe to bot events**: add the message events you want the bridge to receive:
    - `message.im` — direct messages
@@ -84,6 +85,8 @@ Slack app setup:
    - `message.groups` — private channels where the bot is a member
 5. Install/reinstall the app to your workspace after changing scopes or events.
 6. Invite the bot to any channel where it should respond.
+
+Slack image handling supports PNG, JPEG, GIF, and WebP files up to 20 MB. Images are downloaded with the bot token and forwarded to pi as image inputs alongside the Slack message text.
 
 Configure the bridge:
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,7 @@ export function loadConfig(): MsgBridgeConfig {
   }
   if (process.env.PI_SLACK_BOT_TOKEN && process.env.PI_SLACK_APP_TOKEN) {
     config.slack = {
+      ...config.slack,
       botToken: process.env.PI_SLACK_BOT_TOKEN,
       appToken: process.env.PI_SLACK_APP_TOKEN,
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,8 @@ export default function (pi: ExtensionAPI): void {
       if (config.slack?.botToken && config.slack?.appToken) {
         transportPromises.push(
           Promise.resolve().then(() => {
-            const slackProvider = new SlackProvider(config.slack!, auth);
+            const slackConfig = { ...config.slack!, debug: config.debug };
+            const slackProvider = new SlackProvider(slackConfig, auth);
             transportManager.addTransport(slackProvider);
           })
         );
@@ -427,7 +428,8 @@ export default function (pi: ExtensionAPI): void {
 
             config.slack = { ...config.slack, botToken, appToken };
             saveConfig(config);
-            const slackProvider = new SlackProvider(config.slack, auth);
+            const slackConfig = { ...config.slack, debug: config.debug };
+            const slackProvider = new SlackProvider(slackConfig, auth);
             transportManager.addTransport(slackProvider);
             if (acquireLock()) {
               try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,14 +247,29 @@ export default function (pi: ExtensionAPI): void {
       }
 
       if (!hasPendingTools) {
+        await transportManager.setMessageProcessing(
+          pendingRemoteChat.chatId,
+          pendingRemoteChat.transport,
+          pendingRemoteChat.messageId,
+          false
+        );
         pendingRemoteChat = null;
       }
     } catch (err) {
-      const transport = pendingRemoteChat?.transport ?? "unknown";
+      const pending = pendingRemoteChat;
+      const transport = pending?.transport ?? "unknown";
       ctx.ui.notify(
         `Failed to send response to ${transport}: ${(err as Error).message}`,
         "error"
       );
+      if (pending) {
+        await transportManager.setMessageProcessing(
+          pending.chatId,
+          pending.transport,
+          pending.messageId,
+          false
+        );
+      }
       pendingRemoteChat = null;
     }
   });
@@ -410,7 +425,7 @@ export default function (pi: ExtensionAPI): void {
               return;
             }
 
-            config.slack = { botToken, appToken };
+            config.slack = { ...config.slack, botToken, appToken };
             saveConfig(config);
             const slackProvider = new SlackProvider(config.slack, auth);
             transportManager.addTransport(slackProvider);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { AssistantMessage } from "@earendil-works/pi-ai";
+import type { AssistantMessage, ImageContent, TextContent } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import * as fs from "fs";
 import * as os from "os";
@@ -185,7 +185,19 @@ export default function (pi: ExtensionAPI): void {
       };
 
       const taggedMessage = `[📱 @${msg.username} via ${msg.transport}]: ${msg.content}`;
-      pi.sendUserMessage(taggedMessage, { deliverAs: "followUp" });
+      if (msg.images?.length) {
+        const content: (TextContent | ImageContent)[] = [
+          { type: "text", text: taggedMessage },
+          ...msg.images.map((image) => ({
+            type: "image" as const,
+            data: image.data,
+            mimeType: image.mimeType,
+          })),
+        ];
+        pi.sendUserMessage(content, { deliverAs: "followUp" });
+      } else {
+        pi.sendUserMessage(taggedMessage, { deliverAs: "followUp" });
+      }
     });
 
     transportManager.onError((err, transport) => {

--- a/src/transports/interface.ts
+++ b/src/transports/interface.ts
@@ -36,6 +36,13 @@ export interface ITransportProvider {
   sendTyping(chatId: string): Promise<void>;
 
   /**
+   * Optional per-message processing indicator.
+   * Transports that support message reactions can use this to mark an
+   * inbound message as being processed, then clear it when pi is idle.
+   */
+  setMessageProcessing?(chatId: string, messageId: string, processing: boolean): Promise<void>;
+
+  /**
    * Register callback for incoming messages
    * @param handler - Message handler function
    */

--- a/src/transports/manager.ts
+++ b/src/transports/manager.ts
@@ -95,6 +95,21 @@ export class TransportManager {
   }
 
   /**
+   * Set or clear a per-message processing indicator, if the transport supports it.
+   */
+  async setMessageProcessing(
+    chatId: string,
+    transportType: string,
+    messageId: string,
+    processing: boolean
+  ): Promise<void> {
+    const transport = this.transports.get(transportType);
+    if (transport?.isConnected && transport.setMessageProcessing) {
+      await transport.setMessageProcessing(chatId, messageId, processing);
+    }
+  }
+
+  /**
    * Register handler for incoming messages from all transports
    */
   onMessage(handler: (message: ExternalMessage) => void): void {

--- a/src/transports/slack.ts
+++ b/src/transports/slack.ts
@@ -21,6 +21,7 @@ export class SlackProvider implements ITransportProvider {
   private messageHandler?: (message: ExternalMessage) => void;
   private errorHandler?: (error: Error) => void;
   private lastProcessedMessageId = "";
+  private activeBrainReactions = new Set<string>();
   
   // Cache user info to avoid repeated API calls
   private userCache: Map<string, string> = new Map();
@@ -28,7 +29,7 @@ export class SlackProvider implements ITransportProvider {
   private channelCache: Map<string, { isDM: boolean; name?: string }> = new Map();
 
   constructor(
-    private config: { botToken: string; appToken: string },
+    private config: { botToken: string; appToken: string; brainReaction?: boolean },
     private auth: ChallengeAuth
   ) {}
 
@@ -164,6 +165,10 @@ export class SlackProvider implements ITransportProvider {
         return; // Auth handler already sent challenge/error messages
       }
 
+      if (this.config.brainReaction === true) {
+        await this.setMessageProcessing(channelId, ts, true);
+      }
+
       // Forward to message handler
       if (this.messageHandler) {
         const externalMessage: ExternalMessage = {
@@ -210,6 +215,7 @@ export class SlackProvider implements ITransportProvider {
     this._isConnected = false;
     this.userCache.clear();
     this.channelCache.clear();
+    this.activeBrainReactions.clear();
     console.log("[Slack] Disconnected");
   }
 
@@ -230,9 +236,52 @@ export class SlackProvider implements ITransportProvider {
   }
 
   async sendTyping(_chatId: string): Promise<void> {
-    // Slack doesn't support typing indicators for bots
-    // We could potentially add a reaction or use a "thinking" message
-    // but for now we'll just skip it
+    // Slack doesn't support typing indicators for bots.
+  }
+
+  async setMessageProcessing(chatId: string, messageId: string, processing: boolean): Promise<void> {
+    if (this.config.brainReaction !== true) return;
+
+    if (!this.app) {
+      throw new Error("Slack not connected");
+    }
+
+    const key = `${chatId}:${messageId}`;
+
+    try {
+      if (processing) {
+        await this.app.client.reactions.add({
+          channel: chatId,
+          timestamp: messageId,
+          name: "brain",
+        });
+        this.activeBrainReactions.add(key);
+      } else {
+        if (!this.activeBrainReactions.has(key)) return;
+        await this.app.client.reactions.remove({
+          channel: chatId,
+          timestamp: messageId,
+          name: "brain",
+        });
+        this.activeBrainReactions.delete(key);
+      }
+    } catch (error: any) {
+      const slackError = error?.data?.error || error?.message;
+
+      if (processing && slackError === "already_reacted") {
+        this.activeBrainReactions.add(key);
+        return;
+      }
+
+      if (!processing && (slackError === "no_reaction" || slackError === "item_not_found")) {
+        this.activeBrainReactions.delete(key);
+        return;
+      }
+
+      console.warn(
+        `[Slack] Failed to ${processing ? "add" : "remove"} brain reaction: ${slackError || error}`
+      );
+    }
   }
 
   onMessage(handler: (message: ExternalMessage) => void): void {

--- a/src/transports/slack.ts
+++ b/src/transports/slack.ts
@@ -29,7 +29,7 @@ export class SlackProvider implements ITransportProvider {
   private channelCache: Map<string, { isDM: boolean; name?: string }> = new Map();
 
   constructor(
-    private config: { botToken: string; appToken: string; brainReaction?: boolean },
+    private config: { botToken: string; appToken: string; brainReaction?: boolean; debug?: boolean },
     private auth: ChallengeAuth
   ) {}
 
@@ -250,6 +250,9 @@ export class SlackProvider implements ITransportProvider {
 
     try {
       if (processing) {
+        if (this.config.debug) {
+          console.log(`[Slack] Adding brain reaction to message ${messageId} in ${chatId}`);
+        }
         await this.app.client.reactions.add({
           channel: chatId,
           timestamp: messageId,
@@ -258,6 +261,9 @@ export class SlackProvider implements ITransportProvider {
         this.activeBrainReactions.add(key);
       } else {
         if (!this.activeBrainReactions.has(key)) return;
+        if (this.config.debug) {
+          console.log(`[Slack] Removing brain reaction from message ${messageId} in ${chatId}`);
+        }
         await this.app.client.reactions.remove({
           channel: chatId,
           timestamp: messageId,

--- a/src/transports/slack.ts
+++ b/src/transports/slack.ts
@@ -5,6 +5,20 @@ import type { ITransportProvider } from "./interface.js";
 // Dynamic import for ESM modules
 type App = any;
 
+type SlackImageAttachment = {
+  data: string;
+  mimeType: string;
+  name?: string;
+};
+
+const MAX_SLACK_IMAGE_BYTES = 20 * 1024 * 1024;
+const SUPPORTED_IMAGE_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]);
+
 async function loadSlackBolt() {
   const slack = await import("@slack/bolt");
   return slack;
@@ -66,19 +80,28 @@ export class SlackProvider implements ITransportProvider {
 
     // Listen for all messages
     this.app.message(async ({ message, client }: any) => {
-      // Skip bot messages, message edits, deletes, etc.
-      if (message.subtype) {
+      // Skip bot messages, message edits, deletes, etc. Slack file uploads arrive as
+      // `file_share` subtype messages, so keep those and process their image files.
+      if (message.subtype && message.subtype !== "file_share") {
         return;
       }
 
-      // TypeScript type guard for regular messages
-      if (!("user" in message) || !("text" in message) || !message.text) {
+      const files = Array.isArray(message.files) ? message.files : [];
+      const hasImageFiles = files.some((file: any) => this.isSupportedSlackImage(file));
+
+      // TypeScript type guard for regular or image-bearing messages.
+      if (!("user" in message) || !("channel" in message) || !("ts" in message)) {
+        return;
+      }
+
+      const rawText = typeof message.text === "string" ? message.text : "";
+      if (!rawText.trim() && !hasImageFiles) {
         return;
       }
 
       const userId = message.user;
       const channelId = message.channel;
-      const text = message.text;
+      const text = rawText;
       const ts = message.ts;
 
       // Filter out duplicate messages
@@ -169,12 +192,16 @@ export class SlackProvider implements ITransportProvider {
         await this.setMessageProcessing(channelId, ts, true);
       }
 
+      const images = hasImageFiles ? await this.downloadSlackImages(files) : [];
+      const content = this.formatMessageContent(text, files, images);
+
       // Forward to message handler
       if (this.messageHandler) {
         const externalMessage: ExternalMessage = {
           chatId: channelId,
           transport: this.type,
-          content: text.trim(),
+          content,
+          images,
           username: username,
           userId: userId,
           timestamp: new Date(parseFloat(ts) * 1000),
@@ -217,6 +244,78 @@ export class SlackProvider implements ITransportProvider {
     this.channelCache.clear();
     this.activeBrainReactions.clear();
     console.log("[Slack] Disconnected");
+  }
+
+  private isSupportedSlackImage(file: any): boolean {
+    const mimeType = typeof file?.mimetype === "string" ? file.mimetype.toLowerCase() : "";
+    return SUPPORTED_IMAGE_MIME_TYPES.has(mimeType);
+  }
+
+  private async downloadSlackImages(files: any[]): Promise<SlackImageAttachment[]> {
+    const images: SlackImageAttachment[] = [];
+
+    for (const file of files) {
+      if (!this.isSupportedSlackImage(file)) continue;
+
+      const downloadUrl = file.url_private_download || file.url_private;
+      const mimeType = String(file.mimetype).toLowerCase();
+      if (!downloadUrl) continue;
+
+      try {
+        const response = await fetch(downloadUrl, {
+          headers: { Authorization: `Bearer ${this.config.botToken}` },
+        });
+
+        if (!response.ok) {
+          console.warn(`[Slack] Failed to download image ${file.id || file.name}: HTTP ${response.status}`);
+          continue;
+        }
+
+        const contentLength = Number(response.headers.get("content-length") || "0");
+        if (contentLength > MAX_SLACK_IMAGE_BYTES) {
+          console.warn(`[Slack] Skipping image ${file.id || file.name}: file is too large`);
+          continue;
+        }
+
+        const arrayBuffer = await response.arrayBuffer();
+        if (arrayBuffer.byteLength > MAX_SLACK_IMAGE_BYTES) {
+          console.warn(`[Slack] Skipping image ${file.id || file.name}: file is too large`);
+          continue;
+        }
+
+        images.push({
+          data: Buffer.from(arrayBuffer).toString("base64"),
+          mimeType,
+          name: file.name || file.title,
+        });
+      } catch (error) {
+        console.warn(`[Slack] Failed to download image ${file.id || file.name}: ${(error as Error).message}`);
+      }
+    }
+
+    return images;
+  }
+
+  private formatMessageContent(text: string, files: any[], images: SlackImageAttachment[]): string {
+    const trimmed = text.trim();
+    const supportedImageCount = files.filter((file: any) => this.isSupportedSlackImage(file)).length;
+
+    if (images.length === 0 && supportedImageCount > 0) {
+      const plural = supportedImageCount === 1 ? "image was" : "images were";
+      return trimmed
+        ? `${trimmed}\n\n[${supportedImageCount} Slack ${plural} attached but could not be downloaded for model processing.]`
+        : `[${supportedImageCount} Slack ${plural} attached but could not be downloaded for model processing.]`;
+    }
+
+    if (images.length > 0) {
+      const imageNames = images.map((image) => image.name).filter(Boolean).join(", ");
+      const attachmentNote = imageNames
+        ? `[Attached Slack image${images.length === 1 ? "" : "s"}: ${imageNames}]`
+        : `[Attached ${images.length} Slack image${images.length === 1 ? "" : "s"}.]`;
+      return trimmed ? `${trimmed}\n\n${attachmentNote}` : `Please process the attached Slack image${images.length === 1 ? "" : "s"}.\n\n${attachmentNote}`;
+    }
+
+    return trimmed;
   }
 
   async sendMessage(chatId: string, text: string): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,8 @@ export interface MsgBridgeConfig {
   slack?: {
     botToken: string;
     appToken: string;
+    /** Add a :brain: reaction to Slack messages while pi is processing them. Defaults to false. */
+    brainReaction?: boolean;
   };
   discord?: {
     token: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,15 @@
 /**
  * External message received from a messenger transport
  */
+export interface ExternalImageAttachment {
+  /** Base64-encoded image bytes */
+  data: string;
+  /** Image MIME type, e.g. image/png */
+  mimeType: string;
+  /** Optional source filename or title */
+  name?: string;
+}
+
 export interface ExternalMessage {
   /** Unique chat/channel identifier */
   chatId: string;
@@ -8,6 +17,8 @@ export interface ExternalMessage {
   transport: string;
   /** Message content/text */
   content: string;
+  /** Image attachments to send to the model */
+  images?: ExternalImageAttachment[];
   /** Sender username */
   username: string;
   /** Sender user ID */

--- a/src/ui/main-menu.ts
+++ b/src/ui/main-menu.ts
@@ -149,7 +149,7 @@ async function doConfigure(mctx: MenuContext): Promise<void> {
       if (!botToken) return;
       const appToken = await mctx.ui.input("Slack app token (xapp-...)");
       if (!appToken) return;
-      config.slack = { botToken, appToken };
+      config.slack = { ...config.slack, botToken, appToken };
       saveConfig(config);
       const provider = new SlackProvider(config.slack, mctx.auth);
       mctx.transportManager.addTransport(provider);

--- a/src/ui/main-menu.ts
+++ b/src/ui/main-menu.ts
@@ -151,7 +151,8 @@ async function doConfigure(mctx: MenuContext): Promise<void> {
       if (!appToken) return;
       config.slack = { ...config.slack, botToken, appToken };
       saveConfig(config);
-      const provider = new SlackProvider(config.slack, mctx.auth);
+      const slackConfig = { ...config.slack, debug: config.debug };
+      const provider = new SlackProvider(slackConfig, mctx.auth);
       mctx.transportManager.addTransport(provider);
       if (acquireLock()) {
         try {


### PR DESCRIPTION
## Summary

Adds Slack image attachment handling so messages sent through Slack can include image inputs for pi/model processing.

## What changed

- Supports Slack `file_share` messages instead of filtering them out as generic subtypes.
- Downloads supported Slack image attachments using the bot token.
- Forwards downloaded images to pi as structured image content alongside the Slack message text.
- Adds image metadata to `ExternalMessage`.
- Adds fallback message text when Slack images are attached but cannot be downloaded.
- Documents the required Slack `files:read` scope.
- Documents supported image types and size limit.

## Supported image types

- PNG
- JPEG
- GIF
- WebP

Images are limited to 20 MB.

## Slack app requirements

This change requires the Slack bot token to include:

- `files:read`

After adding the scope, the Slack app must be reinstalled to the workspace.

## Testing

Verified that Slack image uploads are received, downloaded, attached to the pi user message, and can be processed by the assistant.