### PR TITLE
feat: self-cross-signing bootstrap for matrix-bot-sdk bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Self-cross-signing bootstrap for matrix-bot-sdk bots — clears Element's "device not verified by its owner" red shield without per-device manual trust. Two paths chosen by which credential is supplied: SSSS recovery-key import (preferred — joins an Element-controlled cross-signing identity) via `PI_MATRIX_RECOVERY_KEY` / `~/.pi/recovery-key.txt`; or fresh-identity creation via `PI_MATRIX_SELF_CROSS_SIGN=reset` (UIA-via-password from `PI_MATRIX_ACCOUNT_PASSWORD` / `~/.pi/pi-password.txt`). Triggered automatically on Matrix connect when encryption is enabled; opt out with `selfCrossSign: false`. Force-pins `@matrix-org/matrix-sdk-crypto-nodejs` to `0.6.0` via npm `overrides`; matrix-bot-sdk's own `^0.4.0` pin silently drops the upload requests `bootstrapCrossSigning` generates.
+
+### Changed
+- Cross-signing helper refuses to silently create a fresh cross-signing identity when no recovery key is on disk. Operators must either provide a recovery key (preferred) or set `selfCrossSign: "reset"` (`PI_MATRIX_SELF_CROSS_SIGN=reset`) to opt into fresh-identity creation. Previously the helper would fall through to `bootstrapCrossSigning(false)` with no opt-in, generating a new server-side identity and orphaning any Element-generated Secure Backup.
+
+### Fixed
+- msg-bridge lock falsely held across container restarts because the liveness check (`process.kill(pid, 0)`) gives a false positive when the new container's PID namespace happens to reassign the same PID number to an unrelated process. Lock format extended to `<pid>:<startTime>:<instanceId>` where `startTime` is `/proc/<pid>/stat` field 22 (jiffies since boot); `acquireLock()` now requires both PID liveness AND `startTime` match to consider the lock held. Legacy 2-field locks are parseable but treated as unconditionally stale on first read after upgrade — they're exactly the format that had the bug, so one acquire-release cycle rewrites them in the new format.
+
 ## [0.4.0] - 2026-05-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ export PI_MATRIX_ACCESS_TOKEN="syt_..."
 
 E2EE is **on by default**. Verify the bot's device once from another Matrix client (Element, etc.) — until verified, encrypted rooms can't be decrypted in either direction.
 
+**Cross-signing setup (recommended).** Without further setup, every encrypted room shows a red "device not verified by its owner" shield on the bot's messages; each user has to manually emoji-verify the bot's device. To make a single one-click verification suffice instead, give the bridge an SSSS recovery key it can use to import an existing cross-signing identity:
+
+1. Log into Element (or Element X) as the bot account in an incognito window.
+2. **Settings → Security & Privacy → Set up Secure Backup → Generate a Security Key.** Copy the `EsT…` key.
+3. Write the key to `~/.pi/recovery-key.txt` (0600), or export it as `PI_MATRIX_RECOVERY_KEY`.
+4. Sign out of Element and (re)start pi. On connect the bridge fetches the encrypted master/self-signing/user-signing keys from the homeserver's account data, decrypts them with the recovery key, imports them locally, and signs its own device.
+
+Other users only need to verify the bot once from their own session afterwards. The bridge **refuses to silently create a fresh cross-signing identity** if no recovery key is provided — that would orphan any existing Element-side Secure Backup. Pass `PI_MATRIX_SELF_CROSS_SIGN=reset` instead to opt into bot-owned identity creation (useful for greenfield bots with no Element session of their own; requires `PI_MATRIX_ACCOUNT_PASSWORD` for UIA on the cross-signing-key upload).
+
 Set `"encryption": false` in the `matrix` config to disable — useful for non-encrypted rooms only, or to bypass crypto-store/server desync (e.g. `M_UNKNOWN: One time key … already exists`). **Caveat:** with E2EE off, the homeserver sees plaintext, and the bot can't participate in encrypted rooms at all.
 
 ### 3. Connect
@@ -185,7 +194,7 @@ Environment variables override file config:
 - `PI_DISCORD_TOKEN` — Discord bot token
 - `PI_MATRIX_HOMESERVER` — Matrix homeserver URL (e.g. `https://matrix.org`)
 - `PI_MATRIX_ACCESS_TOKEN` — Matrix access token
-- `PI_MATRIX_SELF_CROSS_SIGN` — `1` (default when encryption is on) auto-bootstraps the bot's cross-signing identity on connect and signs its own device; `0`/`false` keeps the pre-patch behavior (manual Element-side trust); `reset` forces a fresh identity (invalidates prior trust).
+- `PI_MATRIX_SELF_CROSS_SIGN` — `1` (default when encryption is on) imports the existing cross-signing identity from SSSS if `PI_MATRIX_RECOVERY_KEY` is set, then signs the bot's own device. If neither a recovery key nor `reset` is supplied, the bridge logs an error and leaves the device unsigned rather than silently generating a new identity (which would orphan any Element-side Secure Backup). `0`/`false` skips cross-signing entirely (manual Element-side per-device trust). `reset` opts into creating a fresh bot-owned identity (destroys any prior one; requires `PI_MATRIX_ACCOUNT_PASSWORD` for UIA on `/keys/device_signing/upload`).
 - `PI_MATRIX_ACCOUNT_PASSWORD` — Account password used for UIA if the homeserver requires it for `/keys/upload` cross-signing key upload. Prefer the file-based form below for non-interactive setups.
 - `PI_MATRIX_PASSWORD_FILE` — Path to a 0600 file containing the account password (default `~/.pi/pi-password.txt`). Used only if `PI_MATRIX_ACCOUNT_PASSWORD` isn't set.
 - `PI_MATRIX_RECOVERY_KEY` — SSSS recovery key (base58, as Element generates during "Set up Secure Backup"). When set, the bridge imports the *existing* cross-signing identity from SSSS instead of resetting it — preserves other Element-as-@bot sessions' verification. Takes precedence over the reset path.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ Environment variables override file config:
 - `PI_DISCORD_TOKEN` — Discord bot token
 - `PI_MATRIX_HOMESERVER` — Matrix homeserver URL (e.g. `https://matrix.org`)
 - `PI_MATRIX_ACCESS_TOKEN` — Matrix access token
+- `PI_MATRIX_SELF_CROSS_SIGN` — `1` (default when encryption is on) auto-bootstraps the bot's cross-signing identity on connect and signs its own device; `0`/`false` keeps the pre-patch behavior (manual Element-side trust); `reset` forces a fresh identity (invalidates prior trust).
+- `PI_MATRIX_ACCOUNT_PASSWORD` — Account password used for UIA if the homeserver requires it for `/keys/upload` cross-signing key upload. Prefer the file-based form below for non-interactive setups.
+- `PI_MATRIX_PASSWORD_FILE` — Path to a 0600 file containing the account password (default `~/.pi/pi-password.txt`). Used only if `PI_MATRIX_ACCOUNT_PASSWORD` isn't set.
+- `PI_MATRIX_RECOVERY_KEY` — SSSS recovery key (base58, as Element generates during "Set up Secure Backup"). When set, the bridge imports the *existing* cross-signing identity from SSSS instead of resetting it — preserves other Element-as-@bot sessions' verification. Takes precedence over the reset path.
+- `PI_MATRIX_RECOVERY_KEY_FILE` — Path to a 0600 file containing the recovery key (default `~/.pi/recovery-key.txt`). Used only if `PI_MATRIX_RECOVERY_KEY` isn't set.
 - `MSG_BRIDGE_DEBUG` — Enable debug logging (true/false)
 
 ## Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1557,9 +1557,9 @@
       "license": "MIT"
     },
     "node_modules/@matrix-org/matrix-sdk-crypto-nodejs": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.4.0.tgz",
-      "integrity": "sha512-+qqgpn39XFSbsD0dFjssGO9vHEP7sTyfs8yTpt8vuqWpUpF20QMwpCZi0jpYw7GxjErNTsMshopuo8677DfGEA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.6.0.tgz",
+      "integrity": "sha512-AndGryzkDtFbaDyPBAQ2B4pUhaA/q4HJf3wgiGpPa/70DsdY1Z3R5Wn9yp+56CeHOpk61mNHz/8WDPlzrZDSJw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1567,7 +1567,7 @@
         "node-downloader-helper": "^2.1.9"
       },
       "engines": {
-        "node": ">= 22"
+        "node": ">= 24"
       }
     },
     "node_modules/@mistralai/mistralai": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
     "node-telegram-bot-api": "^0.67.0",
     "qrcode-terminal": "^0.12.0"
   },
+  "overrides": {
+    "@matrix-org/matrix-sdk-crypto-nodejs": "0.6.0"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",
     "@types/node": "^25.6.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,22 @@ export function loadConfig(): MsgBridgeConfig {
       accessToken: process.env.PI_MATRIX_ACCESS_TOKEN,
     };
   }
+  // Cross-signing knobs can refine an existing matrix block without requiring the
+  // homeserver/token to also come from env (mixed file+env config is supported).
+  if (config.matrix) {
+    const xs = process.env.PI_MATRIX_SELF_CROSS_SIGN;
+    if (xs !== undefined) {
+      if (xs === "0" || xs.toLowerCase() === "false") config.matrix.selfCrossSign = false;
+      else if (xs === "reset") config.matrix.selfCrossSign = "reset";
+      else config.matrix.selfCrossSign = true;
+    }
+    if (process.env.PI_MATRIX_ACCOUNT_PASSWORD) {
+      config.matrix.accountPassword = process.env.PI_MATRIX_ACCOUNT_PASSWORD;
+    }
+    if (process.env.PI_MATRIX_RECOVERY_KEY) {
+      config.matrix.recoveryKey = process.env.PI_MATRIX_RECOVERY_KEY;
+    }
+  }
 
   return config;
 }

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -10,6 +10,15 @@ import * as path from "path";
  *                    spawned inside the same Node.js process, same PID).
  *  2. PID lock file — catches separate-process duplicates (e.g. sub-agents
  *                    launched as child processes with different PIDs).
+ *
+ * Lock file format: `<pid>:<startTime>:<instanceId>` where startTime is the
+ * jiffies-since-boot from /proc/<pid>/stat field 22. The startTime guards
+ * against PID-namespace collisions across container restarts — a container
+ * restart can reassign the same PID number to a brand new process; without
+ * the startTime check `process.kill(pid, 0)` would falsely report the old
+ * lock as still held. Legacy 2-field locks (`<pid>:<instanceId>`) are
+ * parseable but treated as stale: that format is exactly what *had* the
+ * PID-collision bug; one acquire after upgrade rewrites in the new format.
  */
 
 const LOCK_PATH = path.join(os.homedir(), ".pi", "msg-bridge.lock");
@@ -20,35 +29,65 @@ if (!g.__msgBridgeInstanceId) {
 }
 const instanceId: string = g.__msgBridgeInstanceId;
 
+interface ParsedLock {
+  pid: number;
+  startTime: string | undefined; // undefined for legacy 2-field locks
+  owner: string;
+}
+
+function parseLock(raw: string): ParsedLock | undefined {
+  const parts = raw.trim().split(":");
+  const pid = parseInt(parts[0], 10);
+  if (Number.isNaN(pid)) return undefined;
+  if (parts.length >= 3) {
+    return { pid, startTime: parts[1], owner: parts.slice(2).join(":") };
+  }
+  return { pid, startTime: undefined, owner: parts[1] ?? "" };
+}
+
+/**
+ * Read /proc/<pid>/stat field 22 (starttime, jiffies since boot). The `comm`
+ * field (parenthesised) may contain spaces or colons, so we anchor on the
+ * final ')' before splitting. Returns undefined on any read/parse error or
+ * on non-Linux platforms.
+ */
+function readProcessStartTime(pid: number): string | undefined {
+  try {
+    const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf-8");
+    const afterComm = stat.slice(stat.lastIndexOf(")") + 1).trim().split(/\s+/);
+    // After ')' the remaining fields are: state(0) ppid(1) ... starttime(19, = field 22)
+    return afterComm[19];
+  } catch {
+    return undefined;
+  }
+}
+
 export function acquireLock(): boolean {
   // Layer 1: same-process guard via a global flag
   if (g.__msgBridgeConnected && g.__msgBridgeOwner !== instanceId) {
     return false;
   }
 
-  // Layer 2: cross-process guard via PID lock file
+  // Layer 2: cross-process guard via PID lock file. The only question that
+  // matters is "is the recorded holder a real, live process right now?" —
+  // not whether its PID happens to equal ours (it can, after a container
+  // restart in a fresh PID namespace), and not whether the owner string
+  // happens to differ from ours (every fresh process picks a new random).
+  // isLockHolderAlive(parsed) is the single source of truth.
   try {
     if (fs.existsSync(LOCK_PATH)) {
-      const raw = fs.readFileSync(LOCK_PATH, "utf-8").trim().split(":");
-      const pid = parseInt(raw[0], 10);
-      const owner = raw[1] ?? "";
-      if (!Number.isNaN(pid) && pid === process.pid && owner !== instanceId) {
+      const parsed = parseLock(fs.readFileSync(LOCK_PATH, "utf-8"));
+      if (parsed && isLockHolderAlive(parsed)) {
         return false;
       }
-      if (!Number.isNaN(pid) && pid !== process.pid) {
-        try {
-          process.kill(pid, 0); // throws if process does not exist
-          return false; // another live process holds the lock
-        } catch {
-          // stale lock from a dead process — overwrite below
-        }
-      }
+      // Otherwise stale — overwrite below.
     }
     const configDir = path.join(os.homedir(), ".pi");
     if (!fs.existsSync(configDir)) {
       fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
     }
-    fs.writeFileSync(LOCK_PATH, `${process.pid}:${instanceId}`, { mode: 0o600 });
+    const startTime = readProcessStartTime(process.pid) ?? "0";
+    fs.writeFileSync(LOCK_PATH, `${process.pid}:${startTime}:${instanceId}`, { mode: 0o600 });
   } catch {
     // lock file mechanics failed — fall through, global flag is still set below
   }
@@ -58,16 +97,35 @@ export function acquireLock(): boolean {
   return true;
 }
 
+/**
+ * True iff some live process is the actual owner of the lock. Requires both
+ * that the PID exists AND that its /proc start_time matches the value
+ * recorded in the lock — defeats PID-namespace collisions across container
+ * restarts. Legacy 2-field locks are treated as unconditionally stale: that
+ * format is precisely what *had* the PID-collision bug, so trusting them
+ * past the upgrade boundary would defeat the point of this fix. One acquire
+ * after upgrade re-writes the lock in the new format.
+ */
+function isLockHolderAlive(parsed: ParsedLock): boolean {
+  if (parsed.startTime === undefined) return false;
+  try {
+    process.kill(parsed.pid, 0);
+  } catch {
+    return false;
+  }
+  const currentStartTime = readProcessStartTime(parsed.pid);
+  if (currentStartTime === undefined) return false;
+  return currentStartTime === parsed.startTime;
+}
+
 export function releaseLock(): void {
   if (g.__msgBridgeOwner !== instanceId) return;
   g.__msgBridgeConnected = false;
   g.__msgBridgeOwner = undefined;
   try {
     if (fs.existsSync(LOCK_PATH)) {
-      const raw = fs.readFileSync(LOCK_PATH, "utf-8").trim().split(":");
-      const pid = parseInt(raw[0], 10);
-      const owner = raw[1] ?? "";
-      if (pid === process.pid && owner === instanceId) {
+      const parsed = parseLock(fs.readFileSync(LOCK_PATH, "utf-8"));
+      if (parsed && parsed.pid === process.pid && parsed.owner === instanceId) {
         fs.unlinkSync(LOCK_PATH);
       }
     }

--- a/src/transports/matrix-crosssign.ts
+++ b/src/transports/matrix-crosssign.ts
@@ -1,0 +1,516 @@
+/**
+ * Self-cross-signing bootstrap for matrix-bot-sdk + @matrix-org/matrix-sdk-crypto-nodejs.
+ *
+ * Mirrors hermes/mautrix-python's pattern (gateway/platforms/matrix.py:775-826).
+ * Two paths, depending on which credential the operator supplies:
+ *
+ * 1. RECOVERY-KEY path (preferred — preserves other @bot Element sessions):
+ *    Given the SSSS recovery key from a prior Element-as-@bot "Set up Secure Backup",
+ *    fetch the encrypted MSK/SSK/USK privates from the homeserver's account_data,
+ *    decrypt them locally with the recovery key, import via
+ *    OlmMachine.importSecretsFromSecretStorage (needs >=0.6.0 of the crypto binding),
+ *    and POST the returned SignatureUploadRequest. The bot joins the existing
+ *    Element-controlled cross-signing identity — no rotation of SSK/MSK on the
+ *    homeserver, no orphaning of other @bot sessions.
+ *
+ * 2. RESET path (fallback — destroys any existing cross-signing on the account):
+ *    Generate a fresh MSK/SSK/USK locally via OlmMachine.bootstrapCrossSigning(true),
+ *    upload them via /keys/device_signing/upload (UIA via password file), then
+ *    POST the device self-signature. The bot becomes the authoritative cross-signer
+ *    for the account — useful for greenfield bots with no Element session of their own.
+ *
+ * If neither credential is supplied, a no-op check confirms an existing self-signature
+ * on the homeserver and warns otherwise. Non-fatal by design — any failure leaves the
+ * bridge running with an unverified device.
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { MatrixClient } from "matrix-bot-sdk";
+import { RustEngine } from "matrix-bot-sdk/lib/e2ee/RustEngine.js";
+import { SecretStorageItems, SecretStorageKey } from "@matrix-org/matrix-sdk-crypto-nodejs";
+
+// matrix-bot-sdk's RustEngine.processToDeviceRequest pulls txn_id / event_type
+// out of `JSON.parse(request.body)`, but `@matrix-org/matrix-sdk-crypto-nodejs` >=
+// 0.5.0 moved them out of the body onto the ToDeviceRequest object itself
+// (request.txnId / request.eventType). Without this patch the bot-sdk passes
+// undefined to client.sendToDevices, napi rejects with "Expect value to be String,
+// but received Undefined", the whole sync loop blows up, and the bridge can't
+// decrypt incoming messages even when megolm keys are available. Required as
+// long as we pin crypto-nodejs >=0.5.0 via npm overrides while matrix-bot-sdk
+// stays on its ^0.4.0 pin.
+(function patchRustEngineForNewBindings() {
+  const proto = (RustEngine as any).prototype;
+  if (!proto || proto.__pi_xsign_patched) return;
+  proto.processToDeviceRequest = async function (request: any) {
+    const body = request.body ? JSON.parse(request.body) : {};
+    const txnId = request.txnId ?? request.txn_id ?? body.txn_id;
+    const eventType = request.eventType ?? request.event_type ?? body.event_type;
+    const messages = body.messages;
+    await this.actuallyProcessToDeviceRequest(txnId, eventType, messages);
+  };
+  proto.__pi_xsign_patched = true;
+})();
+
+export interface CrossSignOptions {
+  /** Account password for UIA. If omitted, unauthenticated upload is attempted and
+   *  failures are logged. Read from PI_MATRIX_ACCOUNT_PASSWORD or the file at
+   *  PI_MATRIX_PASSWORD_FILE upstream of this call. Used only by the RESET path. */
+  password?: string;
+  /** SSSS recovery key (base58, as Element generates it during "Set up Secure Backup").
+   *  When present, take the recovery-key import path instead of bootstrap+reset. Read
+   *  from PI_MATRIX_RECOVERY_KEY or the file at PI_MATRIX_RECOVERY_KEY_FILE upstream. */
+  recoveryKey?: string;
+  /** Force a fresh cross-signing identity, invalidating prior trust. Default false.
+   *  Ignored if recoveryKey is supplied. */
+  reset?: boolean;
+  /** Logger override. Defaults to console.{log,warn}. */
+  log?: (msg: string) => void;
+  warn?: (msg: string) => void;
+}
+
+interface CrossSigningStatus {
+  hasMaster: boolean;
+  hasSelfSigning: boolean;
+  hasUserSigning: boolean;
+}
+
+interface OutgoingRequest {
+  id: string;
+  type: number;
+  body: string;
+  // ToDeviceRequest extras
+  eventType?: string;
+  txnId?: string;
+}
+
+// Mirrors @matrix-org/matrix-sdk-crypto-nodejs's RequestType enum. Hardcoded to
+// avoid taking a dependency on the internal binding (matrix-bot-sdk holds it).
+const REQ_KEYS_UPLOAD = 0;
+const REQ_KEYS_QUERY = 1;
+const REQ_KEYS_CLAIM = 2;
+const REQ_TO_DEVICE = 3;
+const REQ_SIGNATURE_UPLOAD = 4;
+const REQ_ROOM_MESSAGE = 5;
+const REQ_KEYS_BACKUP = 6;
+
+const REQ_NAME: Record<number, string> = {
+  [REQ_KEYS_UPLOAD]: "KeysUpload",
+  [REQ_KEYS_QUERY]: "KeysQuery",
+  [REQ_KEYS_CLAIM]: "KeysClaim",
+  [REQ_TO_DEVICE]: "ToDevice",
+  [REQ_SIGNATURE_UPLOAD]: "SignatureUpload",
+  [REQ_ROOM_MESSAGE]: "RoomMessage",
+  [REQ_KEYS_BACKUP]: "KeysBackup",
+};
+
+/**
+ * Read PI_MATRIX_ACCOUNT_PASSWORD, or the contents of the file at PI_MATRIX_PASSWORD_FILE
+ * (default ~/.pi/pi-password.txt). Returns undefined if neither resolves to a non-empty
+ * string. Refuses files with insecure perms.
+ */
+export function readAccountPassword(): string | undefined {
+  return readSecret(
+    "PI_MATRIX_ACCOUNT_PASSWORD",
+    "PI_MATRIX_PASSWORD_FILE",
+    path.join(os.homedir(), ".pi", "pi-password.txt"),
+    "password"
+  );
+}
+
+/**
+ * Read PI_MATRIX_RECOVERY_KEY, or the contents of the file at PI_MATRIX_RECOVERY_KEY_FILE
+ * (default ~/.pi/recovery-key.txt). Returns undefined if neither resolves to a non-empty
+ * string. Refuses files with insecure perms.
+ */
+export function readRecoveryKey(): string | undefined {
+  return readSecret(
+    "PI_MATRIX_RECOVERY_KEY",
+    "PI_MATRIX_RECOVERY_KEY_FILE",
+    path.join(os.homedir(), ".pi", "recovery-key.txt"),
+    "recovery key"
+  );
+}
+
+function readSecret(envVar: string, fileEnvVar: string, defaultPath: string, label: string): string | undefined {
+  const direct = process.env[envVar];
+  if (direct && direct.trim()) return direct.trim();
+
+  const filePath = process.env[fileEnvVar] || defaultPath;
+  if (!fs.existsSync(filePath)) return undefined;
+
+  try {
+    const stats = fs.statSync(filePath);
+    const mode = stats.mode & 0o777;
+    if ((mode & 0o077) !== 0) {
+      console.warn(`[Matrix xsign] ${label} file ${filePath} has insecure perms ${mode.toString(8)} — refusing to read`);
+      return undefined;
+    }
+    const content = fs.readFileSync(filePath, "utf-8").trim();
+    return content || undefined;
+  } catch (err) {
+    console.warn(`[Matrix xsign] could not read ${label} file ${filePath}: ${(err as Error).message}`);
+    return undefined;
+  }
+}
+
+/**
+ * Drive bootstrapCrossSigning + drain outgoing requests on the bridge's own
+ * OlmMachine. Idempotent: a no-op if the device is already cross-signed.
+ */
+export async function ensureSelfCrossSigned(
+  client: MatrixClient,
+  opts: CrossSignOptions = {}
+): Promise<{ status: "skipped" | "already" | "bootstrapped"; reason?: string }> {
+  const log = opts.log ?? ((m) => console.log(m));
+  const warn = opts.warn ?? ((m) => console.warn(m));
+
+  const machine = (client as any).crypto?.engine?.machine;
+  if (!machine) {
+    return { status: "skipped", reason: "no OlmMachine on client (crypto disabled?)" };
+  }
+
+  const botUserId: string = await client.getUserId();
+
+  // RECOVERY-KEY PATH (preferred): import the existing cross-signing identity from
+  // SSSS using the operator-supplied recovery key, then sign our device with the
+  // imported SSK. Preserves any other @bot session's verification status.
+  if (opts.recoveryKey) {
+    if (await isDeviceCrossSigned(client, botUserId)) {
+      log(`[Matrix xsign] device already cross-signed; ignoring recovery key (use selfCrossSign:"reset" to force rotation)`);
+      return { status: "already" };
+    }
+    log(`[Matrix xsign] importing existing cross-signing identity from SSSS via recovery key`);
+    await importViaRecoveryKey(client, machine, botUserId, opts.recoveryKey, log, warn);
+    return { status: "bootstrapped" };
+  }
+
+  const status: CrossSigningStatus = await machine.crossSigningStatus();
+  const alreadyHasIdentity = status.hasMaster && status.hasSelfSigning && status.hasUserSigning;
+
+  if (alreadyHasIdentity && !opts.reset) {
+    // Confirm the homeserver's view matches: our device should be signed by our SSK.
+    if (await isDeviceCrossSigned(client, botUserId)) {
+      log(`[Matrix xsign] device already cross-signed (msk+ssk+usk present locally and signature visible on homeserver)`);
+      return { status: "already" };
+    }
+    log(`[Matrix xsign] local cross-signing keys present but homeserver hasn't recorded our device signature — re-publishing`);
+  } else {
+    log(`[Matrix xsign] bootstrapping cross-signing (reset=${opts.reset ? "true" : "false"})`);
+  }
+
+  // crypto-nodejs >=0.5.0 returns CrossSigningBootstrapRequests; <0.5.0 returned void
+  // (silently dropping the upload requests — the bug that motivated this helper).
+  const bootstrap: BootstrapRequests = await machine.bootstrapCrossSigning(opts.reset ?? false);
+  if (!bootstrap || typeof bootstrap !== "object" || !("uploadSigningKeysReq" in bootstrap)) {
+    warn(`[Matrix xsign] bootstrapCrossSigning returned no requests — bridge's crypto-nodejs is probably <0.5.0; pin >=0.6.0 via npm overrides`);
+    return { status: "skipped", reason: "binding too old (no CrossSigningBootstrapRequests)" };
+  }
+
+  // 1. uploadKeysReq (device keys) — may be undefined if device keys already on server.
+  if (bootstrap.uploadKeysReq) {
+    const req = bootstrap.uploadKeysReq as any;
+    const resp = await client.doRequest("POST", "/_matrix/client/v3/keys/upload", undefined, JSON.parse(req.body));
+    await machine.markRequestAsSent(req.id, REQ_KEYS_UPLOAD, JSON.stringify(resp ?? {}));
+    log(`[Matrix xsign] uploaded device keys`);
+  }
+
+  // 2. uploadSigningKeysReq — a JSON body string for /keys/device_signing/upload.
+  //    UIA-protected on every Matrix homeserver (no request ID, no markAsSent needed).
+  const signingBody = JSON.parse(bootstrap.uploadSigningKeysReq);
+  await postWithUia(
+    client,
+    "/_matrix/client/v3/keys/device_signing/upload",
+    signingBody,
+    opts.password,
+    log
+  );
+  log(`[Matrix xsign] uploaded cross-signing keys (master/self-signing/user-signing)`);
+
+  // 3. uploadSignaturesReq — the new device's signature, cross-signed by our new SSK.
+  // The Rust SDK wraps the body as `{"signed_keys": {<user>: {<key_id>: signed_device}}}`
+  // but POST /_matrix/client/v3/keys/signatures/upload wants the inner object directly.
+  const sigReq = bootstrap.uploadSignaturesReq as any;
+  const rawSigBody = JSON.parse(sigReq.body);
+  const sigBody = rawSigBody.signed_keys ?? rawSigBody;
+  const sigResp = await client.doRequest(
+    "POST",
+    "/_matrix/client/v3/keys/signatures/upload",
+    undefined,
+    sigBody
+  );
+  await machine.markRequestAsSent(sigReq.id, REQ_SIGNATURE_UPLOAD, JSON.stringify(sigResp ?? {}));
+  log(`[Matrix xsign] uploaded device signatures`);
+
+  // Drain any incidental requests the OlmMachine queued during the above.
+  const drained = await drainOutgoingRequests(client, machine, opts.password, log, warn);
+  if (drained > 0) log(`[Matrix xsign] drained ${drained} follow-up request(s)`);
+
+  return { status: "bootstrapped" };
+}
+
+interface BootstrapRequests {
+  uploadKeysReq?: unknown;
+  uploadSigningKeysReq: string;
+  uploadSignaturesReq: unknown;
+}
+
+/**
+ * Import the existing cross-signing identity (MSK/SSK/USK private parts) from the
+ * homeserver's SSSS using the operator-supplied recovery key, then push the
+ * resulting device self-signature.
+ *
+ * Mirrors the high-level shape of mautrix-python's `verify_with_recovery_key`
+ * but spelled out against the JS Rust SDK bindings (matrix-bot-sdk doesn't surface
+ * any of these — we go straight to the OlmMachine and the homeserver REST API).
+ */
+async function importViaRecoveryKey(
+  client: MatrixClient,
+  machine: any,
+  botUserId: string,
+  recoveryKey: string,
+  log: (m: string) => void,
+  warn: (m: string) => void
+): Promise<void> {
+  const userPath = encodeURIComponent(botUserId);
+
+  // 1. Find the default SSSS key id.
+  let defaultKey: any;
+  try {
+    defaultKey = await client.doRequest("GET", `/_matrix/client/v3/user/${userPath}/account_data/m.secret_storage.default_key`);
+  } catch (err) {
+    throw new Error(`no m.secret_storage.default_key in account_data — operator hasn't run "Set up Secure Backup" in any Element session: ${(err as Error).message}`);
+  }
+  const keyId: string | undefined = defaultKey?.key;
+  if (!keyId) throw new Error("m.secret_storage.default_key is present but has no .key field");
+
+  // 2. Fetch the SSSS key description (algorithm, mac, passphrase params).
+  const keyEventType = `m.secret_storage.key.${keyId}`;
+  const keyContent = await client.doRequest("GET", `/_matrix/client/v3/user/${userPath}/account_data/${encodeURIComponent(keyEventType)}`);
+
+  // 3. Derive the SecretStorageKey from the recovery key + the key description.
+  //    Throws on invalid recovery key / mac mismatch.
+  const ssKey: SecretStorageKey = SecretStorageKey.fromAccountData(recoveryKey, keyEventType, JSON.stringify(keyContent));
+  log(`[Matrix xsign] SSSS key ${keyId} validated against recovery key`);
+
+  // 4. Fetch the encrypted cross-signing private keys from account_data.
+  //    Each entry is an `m.secret_storage.v1.encrypted` object with the SSSS key id
+  //    mapping to {iv, ciphertext, mac}.
+  const fetchSecret = async (name: string) => {
+    try {
+      return await client.doRequest("GET", `/_matrix/client/v3/user/${userPath}/account_data/${encodeURIComponent(name)}`);
+    } catch (err) {
+      throw new Error(`missing account_data ${name} (no Element session has set up cross-signing yet?): ${(err as Error).message}`);
+    }
+  };
+  const masterEvt = await fetchSecret("m.cross_signing.master");
+  const sskEvt = await fetchSecret("m.cross_signing.self_signing");
+  const uskEvt = await fetchSecret("m.cross_signing.user_signing");
+
+  // 5. Hand the encrypted blobs to the Rust SDK, which decrypts + imports them.
+  //    The Record<string, string> keys are snake_case field names on SecretStorageItems
+  //    (master_key / self_signing_key / user_signing_key) per matrix-rust-sdk-crypto-nodejs.
+  //    The values are the inner per-key {iv, ciphertext, mac} blob, JSON-encoded — NOT
+  //    the full `{"encrypted": {<key_id>: ...}}` event wrapper. The SDK is already keyed
+  //    on the SSSS key id we derived; it just wants the cipher bundle.
+  // SecretStorageItems gotchas, both load-bearing:
+  //   - Record keys are camelCase JS names (masterKey / selfSigningKey / userSigningKey).
+  //     The Rust struct is snake_case but napi serializes to camelCase by default;
+  //     using snake_case here throws "missing master key" before the constructor returns.
+  //   - Values are the FULL account_data event JSON ({"encrypted":{<key_id>:{...}}}),
+  //     not the inner cipher bundle. The SDK validates "encrypted" as a field.
+  const items = new SecretStorageItems({
+    masterKey: JSON.stringify(masterEvt),
+    selfSigningKey: JSON.stringify(sskEvt),
+    userSigningKey: JSON.stringify(uskEvt),
+  });
+
+  const sigReq: any = await machine.importSecretsFromSecretStorage(ssKey, items);
+  log(`[Matrix xsign] imported MSK/SSK/USK from SSSS`);
+
+  // 6. Upload the device self-signature so the homeserver records our device as
+  //    cross-signed by the (now locally-known) SSK private.
+  if (sigReq && sigReq.body) {
+    const rawBody = JSON.parse(sigReq.body);
+    const body = rawBody.signed_keys ?? rawBody;
+    const resp = await client.doRequest("POST", "/_matrix/client/v3/keys/signatures/upload", undefined, body);
+    if (sigReq.id) {
+      await machine.markRequestAsSent(sigReq.id, REQ_SIGNATURE_UPLOAD, JSON.stringify(resp ?? {}));
+    }
+    log(`[Matrix xsign] uploaded device signature against imported SSK`);
+  } else {
+    warn(`[Matrix xsign] importSecretsFromSecretStorage returned no SignatureUploadRequest — device may already be signed locally; verify via /keys/query`);
+  }
+
+  // 7. Drain any incidental KeysQuery/KeysUpload the import surfaced.
+  const drained = await drainOutgoingRequests(client, machine, undefined, log, warn);
+  if (drained > 0) log(`[Matrix xsign] drained ${drained} follow-up request(s)`);
+}
+
+/**
+ * Query /_matrix/client/v3/keys/query for our own user and check whether our
+ * device carries a signature from our self_signing_keys's ed25519 keyid.
+ */
+async function isDeviceCrossSigned(client: MatrixClient, botUserId: string): Promise<boolean> {
+  const machine = (client as any).crypto?.engine?.machine;
+  const deviceId: string = machine?.deviceId?.toString?.() ?? "";
+  if (!deviceId) return false;
+  try {
+    const resp = await client.doRequest(
+      "POST",
+      "/_matrix/client/v3/keys/query",
+      undefined,
+      { device_keys: { [botUserId]: [] }, timeout: 5000 }
+    );
+
+    const ssk = resp?.self_signing_keys?.[botUserId];
+    const sskKeyId = ssk?.keys ? Object.keys(ssk.keys)[0] : undefined; // e.g. "ed25519:BASE64"
+    if (!sskKeyId) return false;
+
+    const device = resp?.device_keys?.[botUserId]?.[deviceId];
+    const sigs = device?.signatures?.[botUserId];
+    if (!sigs) return false;
+
+    return Object.prototype.hasOwnProperty.call(sigs, sskKeyId);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Drain machine.outgoingRequests() until empty, dispatching each through the
+ * MatrixClient's HTTP layer. UIA (401 with `flows`) on KeysUpload is the
+ * expected path for device_signing/upload — caught and retried with password.
+ *
+ * Returns the count of requests handled.
+ */
+async function drainOutgoingRequests(
+  client: MatrixClient,
+  machine: any,
+  password: string | undefined,
+  log: (m: string) => void,
+  warn: (m: string) => void
+): Promise<number> {
+  let handled = 0;
+  // Hard cap to avoid an infinite loop if the machine never drains (shouldn't happen).
+  for (let iter = 0; iter < 20; iter++) {
+    const reqs: OutgoingRequest[] = await machine.outgoingRequests();
+    if (!reqs || reqs.length === 0) break;
+
+    for (const req of reqs) {
+      const typeName = REQ_NAME[req.type] ?? `Unknown(${req.type})`;
+      try {
+        const response = await dispatch(client, req, password, log);
+        const responseJson = JSON.stringify(response ?? {});
+        await machine.markRequestAsSent(req.id, req.type, responseJson);
+        handled++;
+        log(`[Matrix xsign] sent ${typeName} (${req.id.slice(0, 8)}) → ack`);
+      } catch (err) {
+        warn(`[Matrix xsign] ${typeName} (${req.id.slice(0, 8)}) failed: ${(err as Error).message}`);
+        // Don't markRequestAsSent on failure — the machine will surface it again next iteration.
+        // Bail out of the loop to avoid hammering the homeserver.
+        return handled;
+      }
+    }
+  }
+  return handled;
+}
+
+async function dispatch(
+  client: MatrixClient,
+  req: OutgoingRequest,
+  password: string | undefined,
+  log: (m: string) => void
+): Promise<any> {
+  const body = req.body ? JSON.parse(req.body) : {};
+
+  switch (req.type) {
+    case REQ_KEYS_UPLOAD:
+      // POST /_matrix/client/v3/keys/upload — may UIA for cross-signing keys upload.
+      return postWithUia(client, "/_matrix/client/v3/keys/upload", body, password, log);
+
+    case REQ_KEYS_QUERY:
+      return client.doRequest("POST", "/_matrix/client/v3/keys/query", undefined, body);
+
+    case REQ_KEYS_CLAIM:
+      return client.doRequest("POST", "/_matrix/client/v3/keys/claim", undefined, body);
+
+    case REQ_TO_DEVICE: {
+      const eventType = req.eventType ?? "m.room.encrypted";
+      const txnId = req.txnId ?? `xsign-${Date.now()}-${req.id.slice(0, 6)}`;
+      // body.messages is { [userId]: { [deviceId]: contentJson } }
+      return client.doRequest(
+        "PUT",
+        `/_matrix/client/v3/sendToDevice/${encodeURIComponent(eventType)}/${encodeURIComponent(txnId)}`,
+        undefined,
+        body
+      );
+    }
+
+    case REQ_SIGNATURE_UPLOAD:
+      return client.doRequest("POST", "/_matrix/client/v3/keys/signatures/upload", undefined, body);
+
+    case REQ_ROOM_MESSAGE:
+      // Not expected during cross-signing; ignore body details for now.
+      throw new Error("RoomMessage request unexpected during cross-signing drain");
+
+    case REQ_KEYS_BACKUP:
+      // Not expected; we don't manage backups here.
+      throw new Error("KeysBackup request unexpected during cross-signing drain");
+
+    default:
+      throw new Error(`Unknown request type ${req.type}`);
+  }
+}
+
+/**
+ * Wrap a POST that may return 401 + UIA flows. On 401 with m.login.password
+ * available, retry once with the password from opts. Otherwise rethrow.
+ */
+async function postWithUia(
+  client: MatrixClient,
+  endpoint: string,
+  body: any,
+  password: string | undefined,
+  log: (m: string) => void
+): Promise<any> {
+  try {
+    return await client.doRequest("POST", endpoint, undefined, body);
+  } catch (err) {
+    const e = err as any;
+    const status = e?.statusCode ?? e?.body?.errcode ? (e?.body ? 401 : undefined) : undefined;
+    const respBody = e?.body ?? e?.response?.body;
+
+    // matrix-bot-sdk surfaces 401 UIA either via thrown error with statusCode or via
+    // an error body containing "flows". Tolerate both shapes.
+    const flows: Array<{ stages?: string[] }> | undefined = respBody?.flows;
+    const session: string | undefined = respBody?.session;
+
+    const isUia = (status === 401 || flows) && Array.isArray(flows) && flows.length > 0;
+    if (!isUia) throw err;
+
+    if (!password) {
+      throw new Error("UIA required but no PI_MATRIX_ACCOUNT_PASSWORD / password file available");
+    }
+
+    const passwordFlow = flows.some((f) => Array.isArray(f.stages) && f.stages.includes("m.login.password"));
+    if (!passwordFlow) {
+      throw new Error(`UIA required but m.login.password not in offered flows: ${JSON.stringify(flows)}`);
+    }
+
+    const botUserId = await client.getUserId();
+    log(`[Matrix xsign] UIA required on ${endpoint} — retrying with m.login.password`);
+
+    const authBody = {
+      ...body,
+      auth: {
+        type: "m.login.password",
+        identifier: { type: "m.id.user", user: botUserId },
+        password,
+        session,
+      },
+    };
+    return await client.doRequest("POST", endpoint, undefined, authBody);
+  }
+}

--- a/src/transports/matrix-crosssign.ts
+++ b/src/transports/matrix-crosssign.ts
@@ -189,6 +189,27 @@ export async function ensureSelfCrossSigned(
   const status: CrossSigningStatus = await machine.crossSigningStatus();
   const alreadyHasIdentity = status.hasMaster && status.hasSelfSigning && status.hasUserSigning;
 
+  // Refuse to silently create a fresh cross-signing identity. Without this guard,
+  // a bot with no recoveryKey and no pre-existing local identity would run
+  // bootstrapCrossSigning(false), which generates fresh MSK/SSK/USK and uploads
+  // them — overwriting any Element-generated cross-signing identity already on
+  // the homeserver. That's what happened on @pi's first connect: the dist build
+  // predated the recovery-key path, no key was loaded, and the bot orphaned the
+  // operator's SSSS Secret Backup. Require an explicit opt-in via reset:true to
+  // create a fresh identity; otherwise demand a recovery key.
+  if (!alreadyHasIdentity && !opts.reset) {
+    const reason = opts.recoveryKey
+      ? "recoveryKey supplied but local identity import didn't run (importViaRecoveryKey threw earlier?)"
+      : "no recoveryKey on disk and reset not explicitly requested";
+    warn(
+      `[Matrix xsign] refusing to generate a fresh cross-signing identity. ${reason}. ` +
+      `Either (a) set PI_MATRIX_RECOVERY_KEY (or write to ~/.pi/recovery-key.txt) to import ` +
+      `an existing Secure Backup identity, or (b) set PI_MATRIX_SELF_CROSS_SIGN=reset to ` +
+      `explicitly create a new bot-owned identity (will destroy any existing one).`
+    );
+    return { status: "skipped", reason: reason };
+  }
+
   if (alreadyHasIdentity && !opts.reset) {
     // Confirm the homeserver's view matches: our device should be signed by our SSK.
     if (await isDeviceCrossSigned(client, botUserId)) {

--- a/src/transports/matrix.ts
+++ b/src/transports/matrix.ts
@@ -12,6 +12,7 @@ import * as os from "os";
 import * as path from "path";
 import type { ChallengeAuth } from "../auth/challenge-auth.js";
 import type { ExternalMessage } from "../types.js";
+import { ensureSelfCrossSigned, readAccountPassword, readRecoveryKey } from "./matrix-crosssign.js";
 import type { ITransportProvider } from "./interface.js";
 import {
   extractUsername,
@@ -37,7 +38,14 @@ export class MatrixProvider implements ITransportProvider {
   private connectedAt = 0;
 
   constructor(
-    private config: { homeserverUrl: string; accessToken: string; encryption?: boolean },
+    private config: {
+      homeserverUrl: string;
+      accessToken: string;
+      encryption?: boolean;
+      selfCrossSign?: boolean | "reset";
+      accountPassword?: string;
+      recoveryKey?: string;
+    },
     private auth: ChallengeAuth
   ) {}
 
@@ -145,6 +153,24 @@ export class MatrixProvider implements ITransportProvider {
 
       // Restore default logging — real errors after sync should not be filtered
       LogService.setLogger(defaultLogger);
+
+      // Self-cross-sign on startup so users only have to verify the bot's master key
+      // once (from any Element session) instead of trusting every bot device manually.
+      // Default-on when encryption is enabled; opt out with selfCrossSign:false.
+      if (cryptoProvider && this.config.selfCrossSign !== false) {
+        const reset = this.config.selfCrossSign === "reset";
+        const password = this.config.accountPassword ?? readAccountPassword();
+        const recoveryKey = this.config.recoveryKey ?? readRecoveryKey();
+        try {
+          const result = await ensureSelfCrossSigned(this.client, { reset, password, recoveryKey });
+          if (result.status === "skipped" && result.reason) {
+            console.warn(`[Matrix] cross-sign skipped: ${result.reason}`);
+          }
+        } catch (e) {
+          // Non-fatal — keep the bridge running with an unverified device on failure.
+          console.warn(`[Matrix] cross-sign failed (non-fatal): ${(e as Error).message}`);
+        }
+      }
     } catch (error) {
       // Clean up dangling state so connect() can be retried
       this.client = undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,22 @@ export interface MsgBridgeConfig {
     homeserverUrl: string;
     accessToken: string;
     encryption?: boolean;
+    /** Auto-bootstrap cross-signing on connect (mirrors hermes/mautrix MATRIX_RECOVERY_KEY
+     *  philosophy). Defaults to true when encryption is on. Set to false to keep the
+     *  pre-patch behavior (manual Element-side trust). Set to "reset" to force a fresh
+     *  cross-signing identity — invalidates trust from other devices/users. */
+    selfCrossSign?: boolean | "reset";
+    /** Account password used for UIA on /_matrix/client/v3/keys/upload when the homeserver
+     *  requires it for cross-signing key upload. Prefer the env-var equivalent
+     *  (PI_MATRIX_ACCOUNT_PASSWORD) or password file (PI_MATRIX_PASSWORD_FILE) to keep the
+     *  password out of msg-bridge.json. */
+    accountPassword?: string;
+    /** SSSS recovery key (base58, as Element generates it during "Set up Secure Backup").
+     *  Triggers the import-from-SSSS path instead of the reset path — preferred when
+     *  another Element-as-@bot session already established cross-signing. Prefer the
+     *  env-var (PI_MATRIX_RECOVERY_KEY) or file (PI_MATRIX_RECOVERY_KEY_FILE) to keep it
+     *  out of msg-bridge.json. */
+    recoveryKey?: string;
   };
   auth?: {
     trustedUsers?: string[];


### PR DESCRIPTION
## Summary

Adds an opt-in self-cross-signing helper so matrix-bot-sdk based bots can clear Element's "device not verified by its owner" red shield without per-device manual trust. Triggered automatically on Matrix connect when encryption is enabled; opt out with `selfCrossSign: false`. Picks one of two paths based on the operator-supplied credential:

- **Recovery-key path (default).** Given the SSSS recovery key from a prior Element-as-@bot "Set up Secure Backup", fetches the encrypted MSK/SSK/USK privates from the homeserver's `account_data`, decrypts locally, imports via `OlmMachine.importSecretsFromSecretStorage`, and POSTs the device self-signature. No UIA. The bot joins an Element-controlled cross-signing identity rather than overwriting it — future bot redeploys can rejoin from the same recovery key.
- **Reset path (opt-in only, `PI_MATRIX_SELF_CROSS_SIGN=reset`).** Fresh-identity creation via `bootstrapCrossSigning(true)` with UIA-via-password retry. For greenfield bots with no Element session of their own.

The helper refuses to silently create a fresh identity without explicit opt-in — that would orphan any existing Element-side Secure Backup.

Also includes:
- Fix for a cross-container PID-collision bug in `src/lock.ts`. The lock format was `<pid>:<instanceId>`; after a container restart the new PID namespace can reassign the same PID number to an unrelated process, and `process.kill(pid, 0)` passes false-positive. Effect: msg-bridge auto-connect silently fell back to "another instance is already connected — skipping" on every restart. New format includes `/proc/<pid>/stat` field 22 (jiffies since boot) so the liveness check requires both PID match AND start_time match.
- README + CHANGELOG updates documenting the new env vars and the recovery-key onboarding flow.

## Technical notes

- Pins `@matrix-org/matrix-sdk-crypto-nodejs` to `0.6.0` via npm `overrides`. matrix-bot-sdk's own `^0.4.0` pin returns `Promise<void>` from `bootstrapCrossSigning` and silently drops the upload requests it generates — `>=0.5.0` returns `CrossSigningBootstrapRequests`. matrix-bot-sdk's `RustEngine` works against the newer binding given a small prototype patch.
- Monkey-patches `RustEngine.processToDeviceRequest` to read `txnId`/`eventType` off the ToDeviceRequest object instead of the deserialized body. Without this, napi rejects with `Expect value to be String, but received Undefined` on every to-device request and the bridge can't decrypt incoming messages.
- Unwraps `uploadSignaturesReq.body.signed_keys` before POSTing — the Rust SDK's nested shape doesn't match what `POST /_matrix/client/v3/keys/signatures/upload` expects (returns `M_BAD_JSON` otherwise).
- `SecretStorageItems` constructor takes camelCase keys (`masterKey`/`selfSigningKey`/`userSigningKey`) and full account_data event JSON values (`{"encrypted": {<key_id>: {...}}}`), not the inner cipher bundle.

## Test plan

- [x] `npm run typecheck` passes.
- [x] `npm run build` succeeds.
- [x] Exercised on a live homeserver (tuwunel) with two bot accounts: recovery-key path verified end-to-end, lock fix verified across container restart, require-key guard verified (no key + no explicit reset → `skipped` with clear error).
- [x] Reviewer: try the recovery-key flow on any matrix-bot-sdk consumer with E2EE enabled — the four commits should drop in cleanly.
